### PR TITLE
fix(fetch): use tuple element for MODEL env var in done hint

### DIFF
--- a/scripts/fetch_models.py
+++ b/scripts/fetch_models.py
@@ -56,7 +56,7 @@ def _download(tier: str, target_dir: Path) -> None:
     print(f"[fetch] {tier} <- {repo}  (-> {dest})", flush=True)
     snapshot_download(repo_id=repo, local_dir=str(dest))
     print(f"[fetch] done: {dest}\n"
-          f"        export {TIER_REPOS[tier].replace('_REPO','_MODEL')}"
+          f"        export {TIER_REPOS[tier][0].replace('_REPO','_MODEL')}"
           f"={dest}")
 
 


### PR DESCRIPTION
## Problem

`scripts/fetch_models.py` crashes with `AttributeError` **after** a download succeeds, making every fetch exit with code 1 even though the checkpoint was fully written to disk.

`TIER_REPOS` values are tuples `("ENV_VAR", "repo_id")`, but `_download()` called `.replace('_REPO','_MODEL')` on the whole tuple:

```python
print(f"        export {TIER_REPOS[tier].replace('_REPO','_MODEL')}={dest}")
```

`tuple` has no `.replace`, so the final `export ...` hint raises, turning a successful download into a failed exit.

## Fix

Index into the first tuple element (the env var name) before replacing:

```python
TIER_REPOS[tier][0].replace('_REPO','_MODEL')
```

This produces the documented env var names `EDGE0_35B_MODEL` / `EDGE0_8B_MODEL` (matching the README's `export EDGE0_35B_MODEL=$PWD/models/edge0-35b`), instead of the wrong `EDGE0_35B_REPO` a naive `.replace` on the tuple would emit.

## Verification

Ran `_download()` for both tiers with `snapshot_download` mocked out — both now print the correct `export EDGE0_*_MODEL=...` hint and return cleanly (no exception):
- `edge0-35b` → `export EDGE0_35B_MODEL=/path/edge0-35b`
- `edge0-8b` → `export EDGE0_8B_MODEL=/path/edge0-8b`
