### PR TITLE
Harden edge0 serve: loopback bind warning and chat request limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ examples/demo.py       # minimal API walkthrough
 - [Attention](docs/attention.md) / [MoE](docs/moe.md) / [SSD streaming](docs/streaming.md) / [prerouter](docs/prerouter.md)
 - [Adding a model](docs/adding-a-model.md)
 - [edge0-35b](docs/models/edge0-35b.md) / [edge0-8b](docs/models/edge0-8b.md)
+- [Hardening `edge0 serve`](docs/HARDENING.md) — loopback default, request caps, residual checkpoint trust
 
 ## License
 

--- a/docs/HARDENING.md
+++ b/docs/HARDENING.md
@@ -1,0 +1,76 @@
+# Hardening `edge0 serve`
+
+The HTTP server exposes an **unauthenticated** OpenAI-compatible API
+(`/healthz`, `/v1/models`, `/v1/chat/completions`). It is intended for
+loopback use on a trusted machine. This page records the default bind,
+request caps, and residual risks that are **not** fully mitigated in
+process.
+
+## Bind to loopback
+
+`edge0 serve` binds `127.0.0.1:8000` by default (CLI `--host` and
+`run_server(host=...)`). Loopback is not reachable from other hosts.
+
+If you pass a non-loopback address (`0.0.0.0`, a LAN IP, `::`, a
+hostname), stderr prints a warning: the process will accept chat
+completions from anyone who can reach that socket, with no API key,
+TLS, or caller identity.
+
+Do not expose `/v1/*` on an untrusted network. If you need remote
+access, put a reverse proxy in front that terminates TLS and
+authenticates callers; `edge0` itself does not implement auth.
+
+## Request limits (chat API)
+
+These caps apply to `POST /v1/chat/completions` and exist to bound
+memory and GPU time, not to replace authentication.
+
+| Limit | Default | HTTP |
+| --- | --- | --- |
+| Request body | 1 MiB | `413` |
+| `max_tokens` | clamped to ≤ 2048 | still `200` (value is capped) |
+| `messages` count | 128 | `400` |
+| Total prompt characters | 100_000 | `400` |
+
+Omitted `max_tokens` keeps the engine/tier default (also 2048 on the
+shipped models). Localhost clients that send a larger OpenAI-style cap
+keep working; generation is truncated at 2048 new tokens.
+
+`POST /v1/completions` remains unsupported (`400`).
+
+## Checkpoints are trusted code
+
+Loading a model directory executes code and templates that ship with
+the checkpoint. Treat every checkpoint the way you would a binary:
+
+- **Jinja `chat_template`**: the Ling / `edge0-8b` engine renders
+  `chat_template.jinja` with Jinja2 (`autoescape=False`, not a sandbox).
+  A malicious template can run Python during `encode_chat`. Qwen-family
+  paths use the tokenizer `apply_chat_template` (also template-driven).
+- **`trust_remote_code` / `auto_map`**: tokenizer load uses Hugging Face
+  `AutoTokenizer.from_pretrained(..., local_files_only=True, trust_remote_code=True)`
+  so a checkpoint `auto_map` can import and run tokenizer code from
+  that directory. Weights are mmap'd safetensors (not pickled), but
+  tokenizer/config side files are not a sandbox.
+
+Only load checkpoints you obtained from a trusted source. This tree
+does not isolate template rendering or tokenizer `auto_map` execution.
+
+## `mlx-lm==0.31.0` (yanked)
+
+`pyproject.toml` pins `mlx-lm==0.31.0`. PyPI has yanked that release
+for **batched KV-cache cross contamination**. Newer `mlx-lm` builds
+have historically crashed edge0 decode (`tolist()` on lazy arrays), so
+this pin is left in place until the full generation suite is re-run
+against a later release.
+
+edge0 serializes chat generations (one request at a time), so the
+yanked batch-cache bug is off the serving path. It is still a known
+dependency risk for any code that uses mlx-lm batch APIs directly.
+
+## What this does not cover
+
+- Authentication, authorization, or TLS
+- Per-IP rate limits or request timeouts
+- Sandboxing Jinja or `trust_remote_code`
+- Prompt injection / model-output trust

--- a/docs/models/edge0-35b.md
+++ b/docs/models/edge0-35b.md
@@ -128,6 +128,8 @@ Response fields (non-streaming):
 
 Optional request fields: `model`, `messages` (with `role`/`content`; content supports multiple text segments that are concatenated automatically), `temperature`, `top_p`, `top_k`, `max_tokens`, `seed`, `stream`.
 
+The serve API is unauthenticated and binds loopback by default. Request bodies are capped at 1 MiB (`413`); `max_tokens` is clamped to 2048; message count and prompt size are bounded. See [HARDENING.md](../HARDENING.md).
+
 ### Streaming chat (requires Flask)
 
 ```bash

--- a/docs/models/edge0-8b.md
+++ b/docs/models/edge0-8b.md
@@ -127,6 +127,8 @@ Response fields (non-streaming):
 
 Optional request fields: `model`, `messages` (with `role`/`content`; content supports multiple text segments that are concatenated automatically), `temperature`, `top_p`, `top_k`, `max_tokens`, `seed`, `stream`.
 
+The serve API is unauthenticated and binds loopback by default. Request bodies are capped at 1 MiB (`413`); `max_tokens` is clamped to 2048; message count and prompt size are bounded. See [HARDENING.md](../HARDENING.md).
+
 ### Streaming chat (requires Flask)
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,13 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    # NOTE: mlx-lm is pinned to 0.31.0 on purpose.  Newer releases crash in
+        # NOTE: mlx-lm is pinned to 0.31.0 on purpose.  Newer releases crash in
     # decode with a `tolist()` on lazily-evaluated arrays.  Do not upgrade
     # without re-running the full test suite.
+    # PyPI yanked 0.31.0 ("Batched KV cache cross contamination").  edge0
+    # serializes generations (one request at a time), so that batch-cache
+    # bug is off the serving path; the pin remains until a later mlx-lm is
+    # verified.  See docs/HARDENING.md.
     "mlx==0.30.4",
     "mlx-metal==0.30.4; platform_system == 'Darwin'",
     "mlx-lm==0.31.0",

--- a/src/edge0/cli.py
+++ b/src/edge0/cli.py
@@ -16,8 +16,14 @@ import os
 import re
 import sys
 
-from edge0 import models  # noqa: F401  (populates MODEL_REGISTRY)
-from edge0.registry import MODEL_REGISTRY
+from edge0.server.limits import insecure_bind_warning
+
+
+def _registry():
+    from edge0 import models  # noqa: F401  (populates MODEL_REGISTRY)
+    from edge0.registry import MODEL_REGISTRY
+    return MODEL_REGISTRY
+
 
 # Tier name -> environment variable that locates that tier's checkpoint
 # (no built-in paths: every machine resolves its own checkpoints).
@@ -33,8 +39,9 @@ DEMO_PROMPTS = {
 
 
 def cmd_models(args) -> int:
-    for name in sorted(MODEL_REGISTRY):
-        mod = MODEL_REGISTRY[name]
+    registry = _registry()
+    for name in sorted(registry):
+        mod = registry[name]
         cfg = mod.Config.from_pretrained(None)  # tier defaults
         print(f"{name}  (port {cfg.port}, target {cfg.target_tok_s} tok/s, "
               f"peak ≈ {cfg.peak_active_mem_mb:.0f} MB)")
@@ -83,7 +90,8 @@ def _resolve_model(args) -> tuple[str | None, str | None]:
     model = getattr(args, "model", None)
     if not model:
         return args.model_dir, args.name
-    if model in MODEL_REGISTRY:
+    registry = _registry()
+    if model in registry:
         env = os.environ.get(TIER_ENV.get(model, ""))
         return env, model
     return model, None  # a path: tier auto-detected by the registry
@@ -184,6 +192,10 @@ def cmd_serve(args) -> int:
     from edge0 import AutoEngine
     from edge0.server import QueueServer, run_server
 
+    warning = insecure_bind_warning(args.host, args.port)
+    if warning:
+        print(warning, file=sys.stderr)
+
     model_dir, name = _resolve_model(args)
     if not model_dir or not os.path.isdir(model_dir):
         raise SystemExit(
@@ -211,7 +223,7 @@ def cmd_convert(args) -> int:
     return 0
 
 
-def main(argv: list[str] | None = None) -> int:
+def build_parser() -> argparse.ArgumentParser:
     ap = argparse.ArgumentParser(prog="edge0", description=__doc__)
     sub = ap.add_subparsers(dest="cmd", required=True)
 
@@ -257,7 +269,10 @@ def main(argv: list[str] | None = None) -> int:
                    help="tier name (edge0-35b) or checkpoint dir")
     p.add_argument("--model-dir", default=None)
     p.add_argument("--name", default=None)
-    p.add_argument("--host", default="127.0.0.1")
+    p.add_argument(
+        "--host", default="127.0.0.1",
+        help="bind address (default: 127.0.0.1 loopback). "
+             "Non-loopback binds expose an unauthenticated /v1/* API.")
     p.add_argument("--port", type=int, default=8000)
     p.add_argument("--flask", action="store_true",
                    help="use the Flask transport (needs flask installed)")
@@ -268,8 +283,11 @@ def main(argv: list[str] | None = None) -> int:
     p = sub.add_parser("convert-adapters",
                        help="one-shot legacy npz -> safetensors migration")
     p.set_defaults(fn=cmd_convert)
+    return ap
 
-    args = ap.parse_args(argv)
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
     return args.fn(args)
 
 

--- a/src/edge0/server/__init__.py
+++ b/src/edge0/server/__init__.py
@@ -4,9 +4,11 @@ from edge0.server.chat import (ChatMessage, ChatRequest, ChatSession,
                                QueueServer, decode_tokens, parse_chat_request,
                                sse_format)
 from edge0.server.app import (create_app, run_server, run_stdlib)
+from edge0.server.limits import ChatRequestError
 
 __all__ = [
     "ChatMessage", "ChatRequest", "ChatSession", "QueueServer",
+    "ChatRequestError",
     "decode_tokens", "parse_chat_request", "sse_format",
     "create_app", "run_server", "run_stdlib",
 ]

--- a/src/edge0/server/app.py
+++ b/src/edge0/server/app.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import queue
+import sys
 import threading
 import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -18,6 +19,11 @@ from urllib.parse import urlparse
 
 from edge0.server.chat import (QueueServer, parse_chat_request, sse_format,
                                decode_tokens)
+from edge0.server.limits import (
+    MAX_REQUEST_BYTES,
+    ChatRequestError,
+    insecure_bind_warning,
+)
 
 try:  # pragma: no cover - environment dependent
     from flask import Flask, Response, jsonify, request  # type: ignore
@@ -28,9 +34,8 @@ except ImportError:  # pragma: no cover
 
 
 def _error(status: int, msg: str) -> tuple:
-    if _HAS_FLASK:
-        return jsonify({"error": {"message": msg, "type": "invalid_request"}}), status
-    return (json.dumps({"error": {"message": msg}}), status)
+    """Transport-agnostic error: ``(payload_dict, status)``."""
+    return {"error": {"message": msg, "type": "invalid_request"}}, status
 
 
 def _split_think(text: str, think: bool):
@@ -73,6 +78,8 @@ def _chat_once(server: QueueServer, payload: dict):
 
 
 def _chat_stream(server: QueueServer, payload: dict):
+    # Parse eagerly so invalid requests 400 *before* SSE headers are sent.
+    # The inner generator is what the transports iterate.
     req = parse_chat_request(payload)
     events = queue.Queue()
     finished = object()
@@ -107,30 +114,36 @@ def _chat_stream(server: QueueServer, payload: dict):
         finally:
             events.put(finished)
 
-    threading.Thread(target=produce, daemon=True).start()
-    while True:
-        event = events.get()
-        if event is finished:
-            return
-        yield event
+    def generate():
+        threading.Thread(target=produce, daemon=True).start()
+        while True:
+            event = events.get()
+            if event is finished:
+                return
+            yield event
+
+    return generate()
 
 
 def build_app_handlers(server: QueueServer):
     """Return a handler dispatch dict shared by both transports."""
 
     def handle_chat(payload: dict):
-        if payload.get("stream"):
-            if _HAS_FLASK:
-                return Response(
-                    _chat_stream(server, payload),
-                    mimetype="text/event-stream",
-                    headers={
-                        "Cache-Control": "no-cache",
-                        "X-Accel-Buffering": "no",
-                    },
-                )
-            return _chat_stream(server, payload)
-        return _chat_once(server, payload)
+        try:
+            if payload.get("stream"):
+                if _HAS_FLASK:
+                    return Response(
+                        _chat_stream(server, payload),
+                        mimetype="text/event-stream",
+                        headers={
+                            "Cache-Control": "no-cache",
+                            "X-Accel-Buffering": "no",
+                        },
+                    )
+                return _chat_stream(server, payload)
+            return _chat_once(server, payload)
+        except ChatRequestError as exc:
+            return _error(exc.status, exc.message)
 
     handlers = {
         "GET /healthz": lambda: {"status": "ok", "model": server.model_name},
@@ -155,7 +168,17 @@ def create_app(server: QueueServer):
         raise ImportError("flask is required for create_app(); "
                           "use run_stdlib instead")
     app = Flask("edge0")
+    app.config["MAX_CONTENT_LENGTH"] = MAX_REQUEST_BYTES
     handlers = build_app_handlers(server)
+
+    @app.errorhandler(413)
+    def _too_large(_err):
+        return jsonify({
+            "error": {
+                "message": "request body too large",
+                "type": "invalid_request",
+            },
+        }), 413
 
     @app.get("/healthz")
     def healthz():
@@ -168,11 +191,17 @@ def create_app(server: QueueServer):
     @app.post("/v1/chat/completions")
     def chat():
         payload = request.get_json(force=True, silent=True) or {}
+        if not isinstance(payload, dict):
+            body, status = _error(400, "JSON object required")
+            return jsonify(body), status
         out = handlers["POST /v1/chat/completions"](payload)
         if isinstance(out, Response):
             return out
-        if isinstance(out, tuple) and out and isinstance(out[0], Response):
-            return out
+        if isinstance(out, tuple):
+            body, status = out[0], out[1]
+            if isinstance(body, Response):
+                return body, status
+            return jsonify(body), status
         return jsonify(out)
 
     @app.post("/v1/completions")
@@ -180,7 +209,8 @@ def create_app(server: QueueServer):
         payload = request.get_json(force=True, silent=True) or {}
         out = handlers["POST /v1/completions"](payload)
         if isinstance(out, tuple):
-            return out
+            body, status = out[0], out[1]
+            return jsonify(body), status
         return jsonify(out)
 
     return app
@@ -229,28 +259,88 @@ class _StdlibHandler(BaseHTTPRequestHandler):
         else:
             self._json(404, {"error": {"message": f"no route {path}"}})
 
+    def _write_handler_result(self, out):
+        """Serialize a handler return value (dict, 2-tuple, or 3-tuple)."""
+        if not isinstance(out, tuple):
+            self._json(200, out)
+            return
+        body, status = out[0], out[1]
+        extra = dict(out[2]) if len(out) > 2 else {}
+        if isinstance(body, dict):
+            self._json(status, body)
+            return
+        get_data = getattr(body, "get_data", None)
+        if callable(get_data):
+            raw = get_data()
+            ctype = getattr(body, "mimetype", None) or "application/json"
+        else:
+            raw = body.encode("utf-8") if isinstance(body, str) else body
+            ctype = "application/json"
+        self.send_response(status)
+        sent_ct = False
+        for k, v in extra.items():
+            self.send_header(k, v)
+            if k.lower() == "content-type":
+                sent_ct = True
+        if not sent_ct:
+            self.send_header("Content-Type", ctype)
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def _read_json_body(self):
+        """Read a POST body capped at ``MAX_REQUEST_BYTES``.
+
+        Returns the parsed object, or None if an error response was already
+        written.
+        """
+        raw_len = self.headers.get("Content-Length", "0")
+        try:
+            length = int(raw_len)
+        except (TypeError, ValueError):
+            self._json(400, {"error": {"message": "invalid Content-Length",
+                                       "type": "invalid_request"}})
+            return None
+        if length < 0:
+            self._json(400, {"error": {"message": "invalid Content-Length",
+                                       "type": "invalid_request"}})
+            return None
+        if length > MAX_REQUEST_BYTES:
+            self.close_connection = True
+            self._json(413, {"error": {"message": "request body too large",
+                                       "type": "invalid_request"}})
+            return None
+        raw = self.rfile.read(length) or b"{}"
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            self._json(400, {"error": {"message": "invalid JSON",
+                                       "type": "invalid_request"}})
+            return None
+
     def do_POST(self):  # noqa: N802
         path = urlparse(self.path).path
         handlers = build_app_handlers(self.server_q)
         if path not in ("/v1/chat/completions", "/v1/completions"):
             self._json(404, {"error": {"message": f"no route {path}"}})
             return
-        length = int(self.headers.get("Content-Length", 0))
-        payload = json.loads(self.rfile.read(length) or b"{}")
-        if path == "/v1/chat/completions" and payload.get("stream"):
-            self._sse(_chat_stream(self.server_q, payload))
+        payload = self._read_json_body()
+        if payload is None:
             return
-        out = handlers[("POST " + path)](payload)
-        if isinstance(out, tuple):
-            body, status, headers = out
-            self.send_response(status)
-            for k, v in headers.items():
-                self.send_header(k, v)
-            self.send_header("Content-Length", str(len(body)))
-            self.end_headers()
-            self.wfile.write(body)
-        else:
-            self._json(200, out)
+        if not isinstance(payload, dict):
+            self._json(400, {"error": {"message": "JSON object required",
+                                       "type": "invalid_request"}})
+            return
+        try:
+            if path == "/v1/chat/completions" and payload.get("stream"):
+                self._sse(_chat_stream(self.server_q, payload))
+                return
+            out = handlers[("POST " + path)](payload)
+        except ChatRequestError as exc:
+            self._json(exc.status, {"error": {"message": exc.message,
+                                              "type": "invalid_request"}})
+            return
+        self._write_handler_result(out)
 
     def log_message(self, fmt, *args):  # quiet by default
         pass
@@ -266,6 +356,9 @@ def run_stdlib(server: QueueServer, host: str, port: int):
 def run_server(server: QueueServer, host: str = "127.0.0.1",
                port: int = 8000, use_flask: bool | None = None):
     """Run the HTTP server in the foreground (blocking)."""
+    warning = insecure_bind_warning(host, port)
+    if warning:
+        print(warning, file=sys.stderr)
     if use_flask is None:
         use_flask = _HAS_FLASK
     if use_flask:

--- a/src/edge0/server/chat.py
+++ b/src/edge0/server/chat.py
@@ -12,9 +12,18 @@ import json
 import threading
 import time
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from edge0.engine.base import Edge0Engine
+if TYPE_CHECKING:
+    from edge0.engine.base import Edge0Engine
+
+from edge0.server.limits import (
+    MAX_MESSAGES,
+    MAX_PROMPT_CHARS,
+    ChatRequestError,
+    clamp_max_tokens,
+    message_text,
+)
 
 
 @dataclass
@@ -38,21 +47,31 @@ class ChatRequest:
 
 
 def parse_chat_request(payload: dict) -> ChatRequest:
+    raw_msgs = payload.get("messages", [])
+    if not isinstance(raw_msgs, list):
+        raise ChatRequestError("messages must be an array")
+    if len(raw_msgs) > MAX_MESSAGES:
+        raise ChatRequestError(
+            f"too many messages (max {MAX_MESSAGES})")
     msgs = []
-    for m in payload.get("messages", []):
+    prompt_chars = 0
+    for m in raw_msgs:
+        if not isinstance(m, dict):
+            raise ChatRequestError("each message must be an object")
         role = str(m.get("role", "user"))
-        content = m.get("content", "")
-        if isinstance(content, list):  # multi-part content: join text parts
-            content = "".join(
-                p.get("text", "") for p in content if isinstance(p, dict))
-        msgs.append(ChatMessage(role=role, content=str(content)))
+        content = message_text(m.get("content", ""))
+        prompt_chars += len(content)
+        if prompt_chars > MAX_PROMPT_CHARS:
+            raise ChatRequestError(
+                f"prompt too large (max {MAX_PROMPT_CHARS} characters)")
+        msgs.append(ChatMessage(role=role, content=content))
     return ChatRequest(
         model=str(payload.get("model", "")),
         messages=msgs,
         temperature=payload.get("temperature"),
         top_p=payload.get("top_p"),
         top_k=payload.get("top_k"),
-        max_tokens=payload.get("max_tokens"),
+        max_tokens=clamp_max_tokens(payload.get("max_tokens")),
         seed=payload.get("seed"),
         stream=bool(payload.get("stream", False)),
         enable_thinking=payload.get("enable_thinking"),

--- a/src/edge0/server/limits.py
+++ b/src/edge0/server/limits.py
@@ -1,0 +1,90 @@
+"""Request and bind-address limits for the unauthenticated serve API.
+
+The OpenAI-compatible HTTP surface has no auth.  These caps exist to
+keep a local ``edge0 serve`` from being an easy resource-exhaustion
+target, and to make non-loopback binds noisy rather than silent.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+
+# HTTP body cap for POST /v1/* (stdlib Content-Length check + Flask
+# MAX_CONTENT_LENGTH).  413 when exceeded.
+MAX_REQUEST_BYTES = 1 * 1024 * 1024  # 1 MiB
+
+# Generation cap applied to request ``max_tokens`` (clamped, not rejected,
+# so localhost clients that send OpenAI-style large caps still work).
+MAX_MAX_TOKENS = 2048
+
+# Chat-compleitions prompt shape.  400 when exceeded.
+MAX_MESSAGES = 128
+MAX_PROMPT_CHARS = 100_000
+
+
+class ChatRequestError(ValueError):
+    """Client-facing request validation failure (HTTP 400 unless noted)."""
+
+    def __init__(self, message: str, status: int = 400):
+        super().__init__(message)
+        self.status = status
+        self.message = message
+
+
+def is_loopback_host(host: str | None) -> bool:
+    """True for loopback literals (127.0.0.1/8, ::1, localhost)."""
+    if not host:
+        return False
+    h = host.strip().lower()
+    if h in {"localhost", "localhost."}:
+        return True
+    if h.startswith("[") and h.endswith("]"):
+        h = h[1:-1]
+    try:
+        addr = ipaddress.ip_address(h)
+    except ValueError:
+        return False
+    mapped = getattr(addr, "ipv4_mapped", None)
+    if mapped is not None:
+        addr = mapped
+    return bool(addr.is_loopback)
+
+
+def insecure_bind_warning(host: str, port: int) -> str | None:
+    """Return a warning if ``host`` is not a loopback bind, else None."""
+    if is_loopback_host(host):
+        return None
+    return (
+        f"[edge0] WARNING: binding {host}:{port} exposes an unauthenticated "
+        "OpenAI-compatible API on a non-loopback interface. "
+        "Do not expose /v1/* to untrusted networks. "
+        "Prefer --host 127.0.0.1 (the default)."
+    )
+
+
+def clamp_max_tokens(value) -> int | None:
+    """Validate and clamp ``max_tokens`` to ``[1, MAX_MAX_TOKENS]``.
+
+    ``None`` (omitted) is left to the engine's generation default.
+    """
+    if value is None:
+        return None
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        raise ChatRequestError("max_tokens must be an integer") from None
+    if n < 1:
+        raise ChatRequestError("max_tokens must be >= 1")
+    if n > MAX_MAX_TOKENS:
+        return MAX_MAX_TOKENS
+    return n
+
+
+def message_text(content) -> str:
+    """Flatten OpenAI message ``content`` (string or multipart list) to text."""
+    if isinstance(content, list):
+        return "".join(
+            p.get("text", "") for p in content if isinstance(p, dict))
+    if content is None:
+        return ""
+    return str(content)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,18 @@
+"""CLI parse tests (no checkpoints, no HTTP)."""
+
+from __future__ import annotations
+
+from edge0.cli import build_parser
+
+
+def test_serve_defaults_to_loopback():
+    args = build_parser().parse_args(["serve", "/tmp/model"])
+    assert args.host == "127.0.0.1"
+    assert args.port == 8000
+
+
+def test_serve_accepts_explicit_non_loopback_host():
+    args = build_parser().parse_args(
+        ["serve", "/tmp/model", "--host", "0.0.0.0", "--port", "8080"])
+    assert args.host == "0.0.0.0"
+    assert args.port == 8080

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -11,9 +11,11 @@ from __future__ import annotations
 import json
 import threading
 import time
+from http.client import HTTPConnection
 from http.server import ThreadingHTTPServer
 from types import SimpleNamespace
 from urllib import request as urlrequest
+from urllib.error import HTTPError
 
 import pytest
 
@@ -35,6 +37,15 @@ from edge0.server.chat import (
     decode_tokens,
     parse_chat_request,
     sse_format,
+)
+from edge0.server.limits import (
+    MAX_MAX_TOKENS,
+    MAX_MESSAGES,
+    MAX_PROMPT_CHARS,
+    MAX_REQUEST_BYTES,
+    ChatRequestError,
+    insecure_bind_warning,
+    is_loopback_host,
 )
 
 
@@ -145,6 +156,47 @@ def test_parse_stream_flag_and_sampling():
     assert req.top_k == 32
     assert req.max_tokens == 16
     assert req.stream is True
+
+
+def test_parse_clamps_max_tokens():
+    req = _req(max_tokens=MAX_MAX_TOKENS + 1000)
+    assert req.max_tokens == MAX_MAX_TOKENS
+
+
+def test_parse_rejects_non_positive_max_tokens():
+    with pytest.raises(ChatRequestError, match="max_tokens"):
+        _req(max_tokens=0)
+    with pytest.raises(ChatRequestError, match="max_tokens"):
+        _req(max_tokens=-8)
+    with pytest.raises(ChatRequestError, match="integer"):
+        _req(max_tokens="nope")
+
+
+def test_parse_rejects_too_many_messages():
+    with pytest.raises(ChatRequestError, match="too many messages"):
+        parse_chat_request({
+            "messages": [{"role": "user", "content": "x"}]
+            * (MAX_MESSAGES + 1),
+        })
+
+
+def test_parse_rejects_oversized_prompt():
+    with pytest.raises(ChatRequestError, match="prompt too large"):
+        parse_chat_request({
+            "messages": [{"role": "user", "content": "a" * (MAX_PROMPT_CHARS + 1)}],
+        })
+
+
+def test_parse_rejects_non_list_messages():
+    with pytest.raises(ChatRequestError, match="array"):
+        parse_chat_request({"messages": "not-a-list"})
+
+
+def test_gen_config_uses_clamped_max_tokens():
+    eng = FakeEngine()
+    sess = ChatSession(eng, _req(max_tokens=10_000))
+    gen = sess.gen_config()
+    assert gen.max_new_tokens == MAX_MAX_TOKENS
 
 
 # ---- sse / decode ---------------------------------------------------------
@@ -262,6 +314,27 @@ def test_handlers_completions_rejected():
     handlers = build_app_handlers(srv)
     body, status = handlers["POST /v1/completions"]({})
     assert status == 400
+    assert body["error"]["type"] == "invalid_request"
+
+
+def test_handlers_reject_too_many_messages():
+    srv = QueueServer(FakeEngine())
+    handlers = build_app_handlers(srv)
+    payload = {
+        "messages": [{"role": "user", "content": "x"}] * (MAX_MESSAGES + 1),
+    }
+    body, status = handlers["POST /v1/chat/completions"](payload)
+    assert status == 400
+    assert "too many messages" in body["error"]["message"]
+
+
+def test_chat_stream_rejects_invalid_before_yielding():
+    srv = QueueServer(FakeEngine())
+    with pytest.raises(ChatRequestError, match="too many messages"):
+        _chat_stream(srv, {
+            "messages": [{"role": "user", "content": "x"}] * (MAX_MESSAGES + 1),
+            "stream": True,
+        })
 
 
 def test_chat_once_response_shape():
@@ -436,3 +509,137 @@ def test_flask_http_streams_before_generation_finishes():
         eng.resume.set()
         response.close()
     assert b"data: [DONE]\n\n" in body
+
+
+def _stdlib_server(eng=None):
+    eng = eng or FakeEngine()
+    srv = QueueServer(eng, model_name="fake")
+    handler = type("Edge0Handler", (_StdlibHandler,), {"server_q": srv})
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    port = httpd.server_address[1]
+    t = threading.Thread(target=httpd.serve_forever, daemon=True)
+    t.start()
+    return httpd, t, port, f"http://127.0.0.1:{port}"
+
+
+def test_stdlib_http_completions_rejected():
+    httpd, t, _port, base = _stdlib_server()
+    try:
+        req = urlrequest.Request(
+            f"{base}/v1/completions", data=b"{}",
+            headers={"Content-Type": "application/json"})
+        with pytest.raises(HTTPError) as exc:
+            urlrequest.urlopen(req, timeout=10)
+        assert exc.value.code == 400
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        t.join(timeout=5)
+
+
+def test_stdlib_http_rejects_too_many_messages():
+    httpd, t, _port, base = _stdlib_server()
+    payload = json.dumps({
+        "messages": [{"role": "user", "content": "x"}] * (MAX_MESSAGES + 1),
+    }).encode("utf-8")
+    try:
+        req = urlrequest.Request(
+            f"{base}/v1/chat/completions", data=payload,
+            headers={"Content-Type": "application/json"})
+        with pytest.raises(HTTPError) as exc:
+            urlrequest.urlopen(req, timeout=10)
+        assert exc.value.code == 400
+        err = json.loads(exc.value.read())
+        assert "too many messages" in err["error"]["message"]
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        t.join(timeout=5)
+
+
+def test_stdlib_http_stream_rejects_too_many_messages():
+    httpd, t, _port, base = _stdlib_server()
+    payload = json.dumps({
+        "messages": [{"role": "user", "content": "x"}] * (MAX_MESSAGES + 1),
+        "stream": True,
+    }).encode("utf-8")
+    try:
+        req = urlrequest.Request(
+            f"{base}/v1/chat/completions", data=payload,
+            headers={"Content-Type": "application/json"})
+        with pytest.raises(HTTPError) as exc:
+            urlrequest.urlopen(req, timeout=10)
+        assert exc.value.code == 400
+        err = json.loads(exc.value.read())
+        assert "too many messages" in err["error"]["message"]
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        t.join(timeout=5)
+
+
+def test_stdlib_http_rejects_oversize_content_length():
+    httpd, t, port, _base = _stdlib_server()
+    conn = HTTPConnection("127.0.0.1", port, timeout=5)
+    try:
+        conn.putrequest("POST", "/v1/chat/completions")
+        conn.putheader("Content-Type", "application/json")
+        conn.putheader("Content-Length", str(MAX_REQUEST_BYTES + 1))
+        conn.endheaders()
+        conn.send(b"{}")
+        resp = conn.getresponse()
+        assert resp.status == 413
+        body = json.loads(resp.read())
+        assert "too large" in body["error"]["message"]
+    finally:
+        conn.close()
+        httpd.shutdown()
+        httpd.server_close()
+        t.join(timeout=5)
+
+
+def test_stdlib_http_clamps_max_tokens():
+    eng = FakeEngine()
+    httpd, t, _port, base = _stdlib_server(eng)
+    payload = json.dumps({
+        "messages": [{"role": "user", "content": "hi"}],
+        "max_tokens": MAX_MAX_TOKENS + 50,
+    }).encode("utf-8")
+    try:
+        req = urlrequest.Request(
+            f"{base}/v1/chat/completions", data=payload,
+            headers={"Content-Type": "application/json"})
+        with urlrequest.urlopen(req, timeout=10) as r:
+            assert r.status == 200
+        gen = eng.generated[0][1]
+        assert gen.max_new_tokens == MAX_MAX_TOKENS
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        t.join(timeout=5)
+
+
+@pytest.mark.skipif(not _HAS_FLASK, reason="flask is not installed")
+def test_flask_rejects_oversize_body():
+    app = create_app(QueueServer(FakeEngine(), model_name="fake"))
+    resp = app.test_client().post(
+        "/v1/chat/completions",
+        data="x" * (MAX_REQUEST_BYTES + 1),
+        content_type="application/json",
+    )
+    assert resp.status_code == 413
+
+
+def test_loopback_bind_helpers():
+    assert is_loopback_host("127.0.0.1")
+    assert is_loopback_host("127.0.0.2")
+    assert is_loopback_host("localhost")
+    assert is_loopback_host("::1")
+    assert is_loopback_host("[::1]")
+    assert not is_loopback_host("0.0.0.0")
+    assert not is_loopback_host("::")
+    assert not is_loopback_host("192.168.1.10")
+    assert not is_loopback_host("example.com")
+    warning = insecure_bind_warning("0.0.0.0", 8000)
+    assert warning and "unauthenticated" in warning
+    assert insecure_bind_warning("127.0.0.1", 8000) is None


### PR DESCRIPTION
## Summary

Harden `edge0 serve` for local use without breaking the localhost OpenAI-compatible API.

The HTTP surface (`/healthz`, `/v1/models`, `/v1/chat/completions`) is **unauthenticated**. This PR makes the default bind harder to misuse and bounds request cost.

### Changes

- **Bind:** CLI `--host` stays `127.0.0.1`. Explicit non-loopback binds (`0.0.0.0`, LAN IPs, `::`, hostnames) print a stderr warning that `/v1/*` has no auth.
- **Chat API limits:**
  - Request body > 1 MiB → `413` (stdlib `Content-Length` check; Flask `MAX_CONTENT_LENGTH`)
  - `max_tokens` clamped to ≤ 2048 (localhost clients that send a large OpenAI-style cap still get `200`)
  - > 128 messages or > 100k prompt characters → `400`
  - `messages` must be an array of objects (avoids iterating a huge string)
- **Docs:** [`docs/HARDENING.md`](docs/HARDENING.md) — localhost default, do not expose `/v1/*` without a proxy/auth, checkpoint trust, yanked `mlx-lm==0.31.0`.
- **Stdlib errors:** `/v1/completions` and validation errors return JSON `400` instead of crashing on a 2-tuple handler result.

`mlx-lm==0.31.0` is **not** bumped. PyPI yanked it for batched KV-cache cross contamination; newer mlx-lm has historically broken edge0 decode (`tolist()` on lazy arrays). edge0 serializes generations (one request at a time), so the batch-cache bug is off the serving path. See `pyproject.toml` and HARDENING.md.

## Residual risks (not fully mitigated here)

These are **trusted-checkpoint** issues, documented rather than sandboxed:

1. **Jinja `chat_template`** — Ling / `edge0-8b` renders `chat_template.jinja` with Jinja2 (`autoescape=False`, not `SandboxedEnvironment`). A malicious template can execute Python during `encode_chat`. Qwen paths use tokenizer `apply_chat_template` (also template-driven).
2. **`trust_remote_code` / `auto_map`** — tokenizer load is `AutoTokenizer.from_pretrained(..., local_files_only=True, trust_remote_code=True)`. A checkpoint `auto_map` can run tokenizer code from that directory. Safetensors weights are mmap'd (not pickled), but tokenizer/config side files are not isolated.

Only load checkpoints from a trusted source. This PR does not add API keys, TLS, rate limits, or a template sandbox.

## Tests

- Unit tests for clamp/reject behavior, 413 on oversize `Content-Length`, 400 on oversized prompts/message lists (including `stream: true` before SSE headers), loopback bind helpers, and `--host` default.
- Ran `pytest tests/test_server.py tests/test_cli.py tests/test_repo_hygiene.py` — **41 passed** (Linux, no MLX; Flask installed).
- MLX math/registry/e2e tests were **not** run here (no Apple Silicon / `mlx` wheels). macOS CI should still cover those; this PR does not change kernels or generation.

## Security rationale

A default or accidental `0.0.0.0` bind would publish an unauthenticated completions API on the LAN. Unbounded `max_tokens`, message lists, and body size let a local (or LAN) client pin GPU/RAM. Caps keep the local-dev API usable while making the dangerous bind noisy and bounding DoS on the chat path.
