### PR TITLE
perf(streaming): page-granular mmap warming with exactness tests and benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - name: Install pytest
-        run: pip install pytest
-      - name: Hygiene checks
-        run: pytest tests/test_repo_hygiene.py
+      - name: Install pytest and NumPy
+        run: pip install pytest numpy
+      - name: Hygiene and mmap checks
+        run: pytest tests/test_repo_hygiene.py tests/test_streaming_mmap.py

--- a/docs/benchmarks/page-warmup.md
+++ b/docs/benchmarks/page-warmup.md
@@ -1,0 +1,150 @@
+# Page-granular mmap warming
+
+## Change and contract
+
+`SafetensorsMmap.touch(offset, length)` reads one byte from each OS page
+intersecting the requested byte range. The mapped file remains read-only.
+The method creates short-lived NumPy views and no payload-sized byte copy.
+
+`seq_read()` uses this method inside its existing traversal windows.
+`StreamingSwitchGLU.warm_pages()` supplies each selected expert's exact
+weight, scale, and bias byte ranges instead of summing all their bytes.
+
+The entry points are explicit expert warming and the Ling startup prewarm
+path (`EDGE0_PREWARM=1`). Normal expert loading, cache policy, routing,
+quantization, and numerical kernels are unchanged. The benefit applies to
+these warming paths; token throughput is outside this benchmark's scope.
+
+## Page-coverage proof
+
+For a nonempty range `[a, a+n)` and OS page size `P`, its page IDs are
+
+`floor(a/P), ..., floor((a+n-1)/P)`.
+
+Read `a` first. Then read every page boundary strictly after `a` and strictly
+before `a+n`. There is exactly one selected address in each intersecting
+page, and every selected address is inside the requested range. Empty ranges
+perform no reads. This also handles the case where a short, unaligned range
+crosses a page boundary. A relative stride starting at `a` alone can miss
+that final page.
+
+The code uses `mmap.PAGESIZE` rather than a fixed 4 KiB assumption. The tests
+instrument the executed address selections for both 4 KiB and 16 KiB pages,
+including 1,000 seeded random ranges per page size and explicit boundary
+cases. The kernel can read ahead or later evict pages; this method establishes
+synchronous reads, not a pinning guarantee or a physical-storage byte count.
+
+## Measurements
+
+Reference: `fbab5f8c08e843e204c0fc6ae18b89a154c652cf`.
+Host: Intel Core i5-3470, Linux x86_64, 4 KiB OS pages, Python 3.12.13,
+NumPy 2.5.3. MLX-dependent checks used MLX 0.30.4 and MLX-LM 0.31.0 on CPU.
+No GPU or phone timing is included.
+
+Each timing comparison randomizes baseline/candidate order within a pair.
+The 128 MiB run has 21 pairs and five operations per sample. The 512 MiB
+replication has 11 pairs and three operations per resident sample. Cold-cache
+samples perform one operation each. Raw timings, seeds, input hashes, and
+source hashes are in the linked JSON files.
+
+| Path | Baseline median | Page reads median | Median paired time reduction |
+|---|---:|---:|---:|
+| Resident 128 MiB whole-shard warmup | 29.731 ms | 0.481 ms | 98.38% |
+| Resident four-expert warming, synthetic byte fixture | 5.438 ms | 0.329 ms | 93.98% |
+| Resident 512 MiB whole-shard warmup | 75.361 ms | 1.971 ms | 97.40% |
+| Explicit warming + materialization of four real experts | 5.593 ms | 1.767 ms | 68.38% |
+
+The last row uses 31 pairs, with three operations per sample. Each operation
+warms the selected expert ranges, calls `_build()` for all four experts, and
+evaluates the resulting MLX arrays. It bypasses cache-hit shortcuts. Its
+paired bootstrap 95% interval for time reduction is **68.20% to 68.53%**.
+It measures that explicit host preparation path, not a complete decoder.
+A separate-process run of the published probe reproduced the exactness checks
+and measured a 73.89% paired reduction; its raw samples are also included.
+
+The real-weight fixture contains nine published Edge0 experts: layers 0,
+20, and 39, each with experts 0, 127, and 255. All gate/up/down weight,
+scale, and bias payloads are preserved. Source checkpoint:
+`Edge0/Edge0-35B-A3B-preview`, revision
+`1ff9f4478890faec0368c5463b621d1036d5b518`. The fixture combines those experts
+into one test layer; it is not a complete checkpoint or a prompt-derived
+activation trace.
+
+### Cold-page-cache control
+
+| Whole-shard path | Baseline median | Page reads median | Paired reduction, 95% interval |
+|---|---:|---:|---:|
+| 128 MiB, file page cache evicted | 486.236 ms | 495.358 ms | -0.90%, [-2.65%, +0.37%] |
+| 512 MiB, file page cache evicted | 2404.585 ms | 2427.666 ms | -0.20%, [-7.05%, +11.44%] |
+
+These runs show no clear cold-cache speed advantage. `mincore` confirmed
+zero resident pages before every cold sample. Eviction targets only the
+benchmark's temporary file with `madvise(DONTNEED)` and
+`posix_fadvise(DONTNEED)`; no global cache flush, root access, or change to
+other files is used. Storage-controller caches are outside this control.
+
+### Allocation and residency
+
+The default old chunk-copy path peaks at **33,554,602 traced bytes** per
+warming call. The page-read path peaks at **34,352 traced bytes** on this
+host. These are `tracemalloc` peaks, not whole-process RSS, device memory,
+or model-capacity measurements.
+
+After either whole-file warming path, Linux `mincore` reports all **32,769**
+128 MiB-fixture pages or all **131,073** 512 MiB-fixture pages resident.
+Input-file SHA-256 remains unchanged.
+
+### Exactness and test execution
+
+- 81 real-weight materialized tensors match byte-for-byte before and after warming.
+- 12 real-expert SwiGLU output comparisons match exactly, using synthetic inputs.
+- 27 backend-free mmap/hygiene tests pass.
+- Full candidate suite on MLX CPU eager execution: 87 passed, 1 skipped,
+  2 slow tests deselected. Matched upstream: 60 passed, 1 skipped, 2 deselected.
+
+With CPU JIT compilation enabled, this host's GCC 15 rejects duplicate
+`_Float32` / `_Float64` typedefs in MLX 0.30.4's bundled preamble. The same
+14 streaming-math failures reproduce on unchanged upstream. The successful
+CPU runs disable compilation only in the test harness. Production code and
+dependency pins are unchanged; the existing macOS/Metal CI remains the
+compiled-backend validation path.
+
+## Reproduce
+
+Backend-free checks and timings require NumPy and pytest:
+
+```sh
+python -m pytest tests/test_streaming_mmap.py tests/test_repo_hygiene.py -q
+python scripts/bench_page_warmup.py --mib 128 --repeats 21 --loops 5 \
+  --cold --json /tmp/edge0-pagewarm-128m.json
+python scripts/bench_page_warmup.py --mib 512 --repeats 11 --loops 3 \
+  --seed 1092026 --cold --json /tmp/edge0-pagewarm-512m.json
+```
+
+Omit `--cold` on macOS. Use `--directory` to select the drive that holds the
+temporary fixture. Timing assertions are deliberately excluded from CI tests.
+
+The optional real-weight probe downloads about 16 MB and requires Requests,
+Safetensors, and the pinned MLX stack. It never downloads the full checkpoint:
+
+```sh
+python -m pip install requests
+python scripts/fetch_pagewarm_samples.py --out /tmp/edge0-pagewarm-samples
+python scripts/bench_page_warmup_mlx.py \
+  --samples /tmp/edge0-pagewarm-samples \
+  --json /tmp/edge0-pagewarm-mlx.json --cpu-eager
+```
+
+Omit `--cpu-eager` for the installed backend's normal execution mode. The
+Linux CPU-eager suite used for these results is reproducible with:
+
+```sh
+PYTHONPATH=src python -c 'import mlx.core as mx; import pytest; mx.set_default_device(mx.cpu); mx.disable_compile(); raise SystemExit(pytest.main(["-q"]))'
+```
+
+## Raw results
+
+[128 MiB paired samples](page-warmup/benchmark_128m.json) ·
+[512 MiB paired samples](page-warmup/benchmark_512m.json) ·
+[Real-weight checks and paired samples](page-warmup/real_weights.json) ·
+[Real-weight separate-process repeat](page-warmup/real_weights_repeat.json)

--- a/docs/benchmarks/page-warmup/benchmark_128m.json
+++ b/docs/benchmarks/page-warmup/benchmark_128m.json
@@ -1,0 +1,449 @@
+{
+  "schema": 1,
+  "python": "3.12.13",
+  "numpy": "2.5.3",
+  "system": "Linux",
+  "machine": "x86_64",
+  "page_bytes": 4096,
+  "fixture_bytes": 134218615,
+  "fixture_sha256": "5ac86406d1a30bfc70efeeacae38aeff45cdaf6aba9f58e9c218d2b7f6971032",
+  "fixture_unchanged": true,
+  "fixture_kind": "synthetic safetensors with checkpoint-sized expert byte spans",
+  "source_sha256": "b533029b2bf33b034544c4b5d2f96a6337ed30aa7a7c8344607fe153fc058401",
+  "legacy_reference_revision": "fbab5f8c08e843e204c0fc6ae18b89a154c652cf",
+  "seed": 20260910,
+  "resident_pages_after_warmup": {
+    "baseline": 32769,
+    "candidate": 32769
+  },
+  "total_mapped_pages": 32769,
+  "allocation": {
+    "baseline_peak_traced_bytes": 33554602,
+    "candidate_peak_traced_bytes": 34352
+  },
+  "benchmarks": [
+    {
+      "name": "resident whole-shard warmup",
+      "pairs": 21,
+      "loops_per_sample": 5,
+      "baseline_median_ms": 29.730976,
+      "candidate_median_ms": 0.48109759999999996,
+      "median_paired_time_reduction": 0.9837748943987448,
+      "paired_reduction_bootstrap_95pct": [
+        0.9835762550392213,
+        0.9839412151300098
+      ],
+      "samples_ns": [
+        {
+          "candidate": 481524.6,
+          "baseline": 29730976.0
+        },
+        {
+          "candidate": 501249.2,
+          "baseline": 29463515.8
+        },
+        {
+          "baseline": 29019045.0,
+          "candidate": 467822.8
+        },
+        {
+          "baseline": 29605141.6,
+          "candidate": 475422.6
+        },
+        {
+          "candidate": 424537.0,
+          "baseline": 29340856.4
+        },
+        {
+          "candidate": 483631.0,
+          "baseline": 29447059.8
+        },
+        {
+          "candidate": 494163.6,
+          "baseline": 30254113.4
+        },
+        {
+          "candidate": 554743.8,
+          "baseline": 29989186.0
+        },
+        {
+          "baseline": 29161355.4,
+          "candidate": 482413.6
+        },
+        {
+          "baseline": 29779646.0,
+          "candidate": 481097.6
+        },
+        {
+          "baseline": 30113633.0,
+          "candidate": 499498.4
+        },
+        {
+          "candidate": 423717.0,
+          "baseline": 29303844.0
+        },
+        {
+          "candidate": 480977.8,
+          "baseline": 30887643.2
+        },
+        {
+          "baseline": 31911822.4,
+          "candidate": 521491.8
+        },
+        {
+          "baseline": 30071737.8,
+          "candidate": 506892.0
+        },
+        {
+          "candidate": 445888.0,
+          "baseline": 29578553.2
+        },
+        {
+          "candidate": 475863.2,
+          "baseline": 29312262.8
+        },
+        {
+          "baseline": 29326687.4,
+          "candidate": 475828.6
+        },
+        {
+          "baseline": 30187203.6,
+          "candidate": 508074.4
+        },
+        {
+          "candidate": 437541.2,
+          "baseline": 30045172.2
+        },
+        {
+          "baseline": 30169737.4,
+          "candidate": 480891.6
+        }
+      ]
+    },
+    {
+      "name": "resident four-expert warmup",
+      "pairs": 21,
+      "loops_per_sample": 5,
+      "baseline_median_ms": 5.4379,
+      "candidate_median_ms": 0.3291786,
+      "median_paired_time_reduction": 0.9397794442987281,
+      "paired_reduction_bootstrap_95pct": [
+        0.9388491734491877,
+        0.9408531876683793
+      ],
+      "samples_ns": [
+        {
+          "baseline": 5574300.8,
+          "candidate": 353888.4
+        },
+        {
+          "baseline": 5412913.0,
+          "candidate": 317406.4
+        },
+        {
+          "baseline": 5449946.0,
+          "candidate": 316127.2
+        },
+        {
+          "baseline": 5397944.4,
+          "candidate": 329178.6
+        },
+        {
+          "baseline": 5428074.6,
+          "candidate": 317955.4
+        },
+        {
+          "baseline": 5381548.8,
+          "candidate": 317858.2
+        },
+        {
+          "baseline": 5372514.6,
+          "candidate": 343957.0
+        },
+        {
+          "baseline": 5625268.2,
+          "candidate": 343989.8
+        },
+        {
+          "baseline": 5448058.6,
+          "candidate": 343635.2
+        },
+        {
+          "baseline": 5478158.2,
+          "candidate": 330207.8
+        },
+        {
+          "candidate": 324735.4,
+          "baseline": 5445575.2
+        },
+        {
+          "candidate": 330199.8,
+          "baseline": 5478306.2
+        },
+        {
+          "candidate": 319509.0,
+          "baseline": 5441917.4
+        },
+        {
+          "baseline": 5387960.0,
+          "candidate": 320255.2
+        },
+        {
+          "candidate": 319713.8,
+          "baseline": 5405427.4
+        },
+        {
+          "candidate": 355294.0,
+          "baseline": 5437900.0
+        },
+        {
+          "candidate": 357160.6,
+          "baseline": 5346095.0
+        },
+        {
+          "candidate": 344948.6,
+          "baseline": 5386577.8
+        },
+        {
+          "candidate": 329424.0,
+          "baseline": 5470291.6
+        },
+        {
+          "baseline": 5427009.6,
+          "candidate": 321345.8
+        },
+        {
+          "baseline": 5471821.8,
+          "candidate": 315975.2
+        }
+      ]
+    },
+    {
+      "name": "cold file-page-cache whole-shard warmup",
+      "pairs": 21,
+      "loops_per_sample": 1,
+      "baseline_median_ms": 486.23637,
+      "candidate_median_ms": 495.358134,
+      "median_paired_time_reduction": -0.008972010417199971,
+      "paired_reduction_bootstrap_95pct": [
+        -0.026480944605575818,
+        0.0037440638181795993
+      ],
+      "samples_ns": [
+        {
+          "candidate": 485829227.0,
+          "baseline": 484908529.0
+        },
+        {
+          "baseline": 513009586.0,
+          "candidate": 495300699.0
+        },
+        {
+          "baseline": 486236370.0,
+          "candidate": 484415870.0
+        },
+        {
+          "candidate": 508170591.0,
+          "baseline": 484616418.0
+        },
+        {
+          "baseline": 485405985.0,
+          "candidate": 498259994.0
+        },
+        {
+          "baseline": 540773039.0,
+          "candidate": 486198039.0
+        },
+        {
+          "baseline": 484681821.0,
+          "candidate": 487493028.0
+        },
+        {
+          "candidate": 520196142.0,
+          "baseline": 484645570.0
+        },
+        {
+          "baseline": 486582567.0,
+          "candidate": 506308847.0
+        },
+        {
+          "baseline": 508440639.0,
+          "candidate": 483066810.0
+        },
+        {
+          "candidate": 483970081.0,
+          "baseline": 528595638.0
+        },
+        {
+          "baseline": 485106627.0,
+          "candidate": 495358134.0
+        },
+        {
+          "candidate": 483265084.0,
+          "baseline": 486365118.0
+        },
+        {
+          "baseline": 520351718.0,
+          "candidate": 533799388.0
+        },
+        {
+          "baseline": 484565279.0,
+          "candidate": 519963694.0
+        },
+        {
+          "baseline": 484952959.0,
+          "candidate": 489303962.0
+        },
+        {
+          "baseline": 484595743.0,
+          "candidate": 508998397.0
+        },
+        {
+          "candidate": 482838223.0,
+          "baseline": 499532154.0
+        },
+        {
+          "baseline": 484714515.0,
+          "candidate": 497225828.0
+        },
+        {
+          "baseline": 503103548.0,
+          "candidate": 504870921.0
+        },
+        {
+          "baseline": 486977805.0,
+          "candidate": 541557696.0
+        }
+      ],
+      "preconditions_in_execution_order": [
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        }
+      ]
+    }
+  ],
+  "scope": "Host warming latency and traced temporary allocation only. No token-rate, model-quality, disk-bandwidth, GPU, or iPhone claim. Cold means this temporary file's OS page cache; storage-controller caches are not flushed."
+}

--- a/docs/benchmarks/page-warmup/benchmark_512m.json
+++ b/docs/benchmarks/page-warmup/benchmark_512m.json
@@ -1,0 +1,269 @@
+{
+  "schema": 1,
+  "python": "3.12.13",
+  "numpy": "2.5.3",
+  "system": "Linux",
+  "machine": "x86_64",
+  "page_bytes": 4096,
+  "fixture_bytes": 536871799,
+  "fixture_sha256": "4a6e416502851daeaeee265ff65d219f7a006965c80ff500850cd8f3413a6e08",
+  "fixture_unchanged": true,
+  "fixture_kind": "synthetic safetensors with checkpoint-sized expert byte spans",
+  "source_sha256": "b533029b2bf33b034544c4b5d2f96a6337ed30aa7a7c8344607fe153fc058401",
+  "legacy_reference_revision": "fbab5f8c08e843e204c0fc6ae18b89a154c652cf",
+  "seed": 1092026,
+  "resident_pages_after_warmup": {
+    "baseline": 131073,
+    "candidate": 131073
+  },
+  "total_mapped_pages": 131073,
+  "allocation": {
+    "baseline_peak_traced_bytes": 33554602,
+    "candidate_peak_traced_bytes": 34352
+  },
+  "benchmarks": [
+    {
+      "name": "resident whole-shard warmup",
+      "pairs": 11,
+      "loops_per_sample": 3,
+      "baseline_median_ms": 75.361418,
+      "candidate_median_ms": 1.9708773333333331,
+      "median_paired_time_reduction": 0.9740464380965341,
+      "paired_reduction_bootstrap_95pct": [
+        0.9721992318739525,
+        0.9764705949465028
+      ],
+      "samples_ns": [
+        {
+          "baseline": 77105571.66666667,
+          "candidate": 2528878.6666666665
+        },
+        {
+          "candidate": 1856110.3333333333,
+          "baseline": 78884711.66666667
+        },
+        {
+          "candidate": 1951844.0,
+          "baseline": 74789757.0
+        },
+        {
+          "candidate": 2007413.0,
+          "baseline": 74987507.0
+        },
+        {
+          "candidate": 2081779.0,
+          "baseline": 74882067.66666667
+        },
+        {
+          "candidate": 1982017.6666666667,
+          "baseline": 77178195.66666667
+        },
+        {
+          "baseline": 76699992.66666667,
+          "candidate": 1970877.3333333333
+        },
+        {
+          "candidate": 1629052.0,
+          "baseline": 75234773.0
+        },
+        {
+          "baseline": 75000418.33333333,
+          "candidate": 1946528.0
+        },
+        {
+          "candidate": 1647829.0,
+          "baseline": 75361418.0
+        },
+        {
+          "candidate": 2316944.6666666665,
+          "baseline": 78111125.66666667
+        }
+      ]
+    },
+    {
+      "name": "resident four-expert warmup",
+      "pairs": 11,
+      "loops_per_sample": 3,
+      "baseline_median_ms": 4.13863,
+      "candidate_median_ms": 0.328769,
+      "median_paired_time_reduction": 0.9196082177538158,
+      "paired_reduction_bootstrap_95pct": [
+        0.9182195937161949,
+        0.9235211628878567
+      ],
+      "samples_ns": [
+        {
+          "baseline": 4138630.0,
+          "candidate": 332877.0
+        },
+        {
+          "baseline": 4190520.0,
+          "candidate": 372776.6666666667
+        },
+        {
+          "baseline": 4281031.333333333,
+          "candidate": 324370.3333333333
+        },
+        {
+          "candidate": 326677.6666666667,
+          "baseline": 4079010.0
+        },
+        {
+          "candidate": 326881.3333333333,
+          "baseline": 4274141.0
+        },
+        {
+          "candidate": 332644.6666666667,
+          "baseline": 4130450.0
+        },
+        {
+          "candidate": 323849.6666666667,
+          "baseline": 4242188.0
+        },
+        {
+          "candidate": 349521.3333333333,
+          "baseline": 4133975.3333333335
+        },
+        {
+          "candidate": 324446.3333333333,
+          "baseline": 4119905.6666666665
+        },
+        {
+          "candidate": 352695.6666666667,
+          "baseline": 4312716.0
+        },
+        {
+          "baseline": 4089584.6666666665,
+          "candidate": 328769.0
+        }
+      ]
+    },
+    {
+      "name": "cold file-page-cache whole-shard warmup",
+      "pairs": 11,
+      "loops_per_sample": 1,
+      "baseline_median_ms": 2404.584703,
+      "candidate_median_ms": 2427.666293,
+      "median_paired_time_reduction": -0.0019769688750579384,
+      "paired_reduction_bootstrap_95pct": [
+        -0.07048588235632103,
+        0.11441949479690117
+      ],
+      "samples_ns": [
+        {
+          "baseline": 2254586971.0,
+          "candidate": 2413503523.0
+        },
+        {
+          "candidate": 2392890697.0,
+          "baseline": 2404584703.0
+        },
+        {
+          "baseline": 2379239603.0,
+          "candidate": 2427666293.0
+        },
+        {
+          "candidate": 2401379779.0,
+          "baseline": 2711644808.0
+        },
+        {
+          "baseline": 2308685612.0,
+          "candidate": 2927765936.0
+        },
+        {
+          "baseline": 2280133986.0,
+          "candidate": 3387017893.0
+        },
+        {
+          "candidate": 3388127215.0,
+          "baseline": 3381442209.0
+        },
+        {
+          "baseline": 2965899814.0,
+          "candidate": 2590143562.0
+        },
+        {
+          "baseline": 2458972002.0,
+          "candidate": 2496009758.0
+        },
+        {
+          "baseline": 2587751246.0,
+          "candidate": 2278484480.0
+        },
+        {
+          "candidate": 2284971775.0,
+          "baseline": 2316126619.0
+        }
+      ],
+      "preconditions_in_execution_order": [
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        },
+        {
+          "resident_pages_before": 0
+        }
+      ]
+    }
+  ],
+  "scope": "Host warming latency and traced temporary allocation only. No token-rate, model-quality, disk-bandwidth, GPU, or iPhone claim. Cold means this temporary file's OS page cache; storage-controller caches are not flushed."
+}

--- a/docs/benchmarks/page-warmup/real_weights.json
+++ b/docs/benchmarks/page-warmup/real_weights.json
@@ -1,0 +1,194 @@
+{
+  "repo": "Edge0/Edge0-35B-A3B-preview",
+  "weight_revision": "1ff9f4478890faec0368c5463b621d1036d5b518",
+  "sample_experts": [
+    [
+      0,
+      0
+    ],
+    [
+      0,
+      127
+    ],
+    [
+      0,
+      255
+    ],
+    [
+      20,
+      0
+    ],
+    [
+      20,
+      127
+    ],
+    [
+      20,
+      255
+    ],
+    [
+      39,
+      0
+    ],
+    [
+      39,
+      127
+    ],
+    [
+      39,
+      255
+    ]
+  ],
+  "python": "3.12.13",
+  "numpy": "2.5.3",
+  "mlx": "0.30.4",
+  "device": "MLX CPU; compilation disabled in the test harness only",
+  "weight_bytes": 15925248,
+  "materialized_tensors_exact": 81,
+  "exact_swiglu_output_checks": 12,
+  "warm_and_materialize": {
+    "pairs": 31,
+    "loops": 3,
+    "selected_experts": [
+      0,
+      3,
+      5,
+      8
+    ],
+    "baseline_median_ms": 5.593480333333333,
+    "candidate_median_ms": 1.7670436666666667,
+    "median_paired_time_reduction": 0.6838224317734539,
+    "bootstrap_95pct": [
+      0.6820057041103865,
+      0.6853373343513438
+    ],
+    "samples_ns": [
+      {
+        "baseline": 5638255.0,
+        "candidate": 1763535.0
+      },
+      {
+        "baseline": 5536427.333333333,
+        "candidate": 1750069.0
+      },
+      {
+        "baseline": 5545049.666666667,
+        "candidate": 1787265.6666666667
+      },
+      {
+        "candidate": 1766829.6666666667,
+        "baseline": 5629031.666666667
+      },
+      {
+        "baseline": 5710555.333333333,
+        "candidate": 1764623.0
+      },
+      {
+        "candidate": 1788099.0,
+        "baseline": 5544739.333333333
+      },
+      {
+        "candidate": 1777030.0,
+        "baseline": 5717504.666666667
+      },
+      {
+        "baseline": 5631900.0,
+        "candidate": 1772148.6666666667
+      },
+      {
+        "candidate": 1752129.6666666667,
+        "baseline": 5559230.666666667
+      },
+      {
+        "candidate": 1774133.0,
+        "baseline": 5579134.666666667
+      },
+      {
+        "candidate": 1753732.0,
+        "baseline": 5546668.0
+      },
+      {
+        "baseline": 5518401.666666667,
+        "candidate": 1795659.0
+      },
+      {
+        "baseline": 5519421.333333333,
+        "candidate": 1759357.0
+      },
+      {
+        "candidate": 1760451.6666666667,
+        "baseline": 5549939.333333333
+      },
+      {
+        "baseline": 6379600.333333333,
+        "candidate": 2357665.3333333335
+      },
+      {
+        "baseline": 6310819.666666667,
+        "candidate": 2222261.6666666665
+      },
+      {
+        "candidate": 2077214.6666666667,
+        "baseline": 5972206.333333333
+      },
+      {
+        "baseline": 6236598.333333333,
+        "candidate": 1992461.3333333333
+      },
+      {
+        "baseline": 5641269.0,
+        "candidate": 1753192.6666666667
+      },
+      {
+        "baseline": 5750738.333333333,
+        "candidate": 1762329.3333333333
+      },
+      {
+        "baseline": 5621287.333333333,
+        "candidate": 1747226.0
+      },
+      {
+        "candidate": 1750757.3333333333,
+        "baseline": 5521264.666666667
+      },
+      {
+        "baseline": 5593480.333333333,
+        "candidate": 1767043.6666666667
+      },
+      {
+        "candidate": 1747319.0,
+        "baseline": 5517640.666666667
+      },
+      {
+        "candidate": 1769006.3333333333,
+        "baseline": 5569227.333333333
+      },
+      {
+        "candidate": 1789391.0,
+        "baseline": 5586831.333333333
+      },
+      {
+        "baseline": 5722581.0,
+        "candidate": 2056658.3333333333
+      },
+      {
+        "baseline": 5923441.666666667,
+        "candidate": 1776343.6666666667
+      },
+      {
+        "candidate": 1742913.3333333333,
+        "baseline": 5525502.0
+      },
+      {
+        "candidate": 1746510.6666666667,
+        "baseline": 5585276.0
+      },
+      {
+        "baseline": 5701901.333333333,
+        "candidate": 1785144.0
+      }
+    ]
+  },
+  "file_unchanged": true,
+  "scope": "Actual materialization of nine published experts and 12 exact SwiGLU output comparisons with synthetic inputs. Paired latency covers explicit page warming followed by four expert builds and MLX CPU eval. It is not full-model inference, token throughput, or an end-to-end quality benchmark."
+}

--- a/docs/benchmarks/page-warmup/real_weights_repeat.json
+++ b/docs/benchmarks/page-warmup/real_weights_repeat.json
@@ -1,0 +1,195 @@
+{
+  "repo": "Edge0/Edge0-35B-A3B-preview",
+  "weight_revision": "1ff9f4478890faec0368c5463b621d1036d5b518",
+  "sample_experts": [
+    [
+      0,
+      0
+    ],
+    [
+      0,
+      127
+    ],
+    [
+      0,
+      255
+    ],
+    [
+      20,
+      0
+    ],
+    [
+      20,
+      127
+    ],
+    [
+      20,
+      255
+    ],
+    [
+      39,
+      0
+    ],
+    [
+      39,
+      127
+    ],
+    [
+      39,
+      255
+    ]
+  ],
+  "python": "3.12.13",
+  "numpy": "2.5.3",
+  "mlx": "0.30.4",
+  "device": "Device(cpu, 0)",
+  "cpu_eager": true,
+  "weight_bytes": 15925248,
+  "materialized_tensors_exact": 81,
+  "exact_swiglu_output_checks": 12,
+  "warm_and_materialize": {
+    "pairs": 31,
+    "loops": 3,
+    "selected_experts": [
+      0,
+      3,
+      5,
+      8
+    ],
+    "baseline_median_ms": 6.795596666666667,
+    "candidate_median_ms": 1.7819023333333333,
+    "median_paired_time_reduction": 0.7388905029403481,
+    "bootstrap_95pct": [
+      0.7378835121629647,
+      0.7405069723265426
+    ],
+    "samples_ns": [
+      {
+        "baseline": 6911028.666666667,
+        "candidate": 1815396.3333333333
+      },
+      {
+        "baseline": 6923505.333333333,
+        "candidate": 1784438.3333333333
+      },
+      {
+        "baseline": 6824186.0,
+        "candidate": 1788731.6666666667
+      },
+      {
+        "candidate": 1783372.6666666667,
+        "baseline": 7402939.333333333
+      },
+      {
+        "baseline": 6975392.333333333,
+        "candidate": 1826133.0
+      },
+      {
+        "candidate": 1809012.6666666667,
+        "baseline": 6930524.666666667
+      },
+      {
+        "candidate": 1754588.3333333333,
+        "baseline": 6776902.0
+      },
+      {
+        "baseline": 6777050.0,
+        "candidate": 1784855.0
+      },
+      {
+        "candidate": 1783308.3333333333,
+        "baseline": 6810423.333333333
+      },
+      {
+        "candidate": 1781902.3333333333,
+        "baseline": 6790238.0
+      },
+      {
+        "candidate": 1752687.6666666667,
+        "baseline": 6791732.0
+      },
+      {
+        "baseline": 6774991.666666667,
+        "candidate": 1769014.6666666667
+      },
+      {
+        "baseline": 6782941.666666667,
+        "candidate": 1780311.0
+      },
+      {
+        "candidate": 1736513.3333333333,
+        "baseline": 6997973.666666667
+      },
+      {
+        "baseline": 6944548.333333333,
+        "candidate": 1793232.3333333333
+      },
+      {
+        "baseline": 6791099.333333333,
+        "candidate": 1791946.6666666667
+      },
+      {
+        "candidate": 1772040.0,
+        "baseline": 6828854.0
+      },
+      {
+        "baseline": 6779208.333333333,
+        "candidate": 1843826.3333333333
+      },
+      {
+        "baseline": 6818428.0,
+        "candidate": 1773244.6666666667
+      },
+      {
+        "baseline": 6768295.666666667,
+        "candidate": 1790447.6666666667
+      },
+      {
+        "baseline": 6795457.0,
+        "candidate": 1727289.6666666667
+      },
+      {
+        "candidate": 1775174.3333333333,
+        "baseline": 6795596.666666667
+      },
+      {
+        "baseline": 6779529.0,
+        "candidate": 1831442.3333333333
+      },
+      {
+        "candidate": 1802888.0,
+        "baseline": 6792329.666666667
+      },
+      {
+        "candidate": 1733217.6666666667,
+        "baseline": 6811425.333333333
+      },
+      {
+        "candidate": 1785109.3333333333,
+        "baseline": 6780617.666666667
+      },
+      {
+        "baseline": 6796815.0,
+        "candidate": 1768386.6666666667
+      },
+      {
+        "baseline": 6789114.333333333,
+        "candidate": 1733732.3333333333
+      },
+      {
+        "candidate": 1779244.6666666667,
+        "baseline": 6813241.666666667
+      },
+      {
+        "candidate": 1769304.0,
+        "baseline": 6778268.666666667
+      },
+      {
+        "baseline": 6867191.0,
+        "candidate": 1775879.3333333333
+      }
+    ]
+  },
+  "file_unchanged": true,
+  "scope": "Actual materialization of nine published experts and 12 exact SwiGLU output comparisons with synthetic inputs. Paired latency covers explicit page warming followed by four expert builds and MLX eval. It is not full-model inference, token throughput, or an end-to-end quality benchmark."
+}

--- a/scripts/bench_page_warmup.py
+++ b/scripts/bench_page_warmup.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Benchmark page warming against the previous byte-copy/byte-sum paths.
+
+Requires NumPy only; no MLX, model download, GPU, root, or global cache flush.
+The optional Linux cold-page-cache test evicts ONLY its own temporary file.
+Results measure host warming work, not token throughput or physical I/O bytes.
+"""
+from __future__ import annotations
+
+import argparse
+import ctypes
+import hashlib
+import importlib.util
+import json
+import mmap
+import os
+from pathlib import Path
+import platform
+import struct
+import tempfile
+import time
+import tracemalloc
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = ROOT / "src/edge0/streaming/mmap.py"
+spec = importlib.util.spec_from_file_location("edge0_mmap_benchmark", SOURCE)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+
+def legacy_seq_read(shard, chunk=1 << 24):
+    for offset in range(0, len(shard._mm), chunk):
+        _ = shard._mm[offset:offset + chunk]
+
+
+def legacy_expert_warm(shard, ranges):
+    for name, expert, count in ranges:
+        raw = shard.raw(name)
+        per = raw.size // count
+        _ = raw[expert * per:(expert + 1) * per].sum()
+
+
+def page_expert_warm(shard, ranges):
+    for name, expert, count in ranges:
+        entry = shard.entries[name]
+        per = entry["size"] // count
+        shard.touch(entry["offset"] + expert * per, per)
+
+
+def write_fixture(path, mib):
+    # Four gate/up/down expert bundles with checkpoint-sized packed weights
+    # and BF16 scale/bias byte spans. A filler tensor sets the shard size.
+    shapes = {}
+    offset = 0
+    for proj in ("gate", "up", "down"):
+        for part, per in (("weight", 524288), ("scales", 32768), ("biases", 32768)):
+            size = 4 * per
+            shapes[f"{proj}.{part}"] = {"dtype": "U8", "shape": [4, per],
+                                        "data_offsets": [offset, offset + size]}
+            offset += size
+    total = mib * (1 << 20)
+    if total < offset:
+        raise ValueError("fixture must be at least 7 MiB")
+    shapes["filler"] = {"dtype": "U8", "shape": [total - offset],
+                        "data_offsets": [offset, total]}
+    header = json.dumps(shapes).encode()
+    rng = np.random.default_rng(812)
+    block = rng.integers(0, 256, 1 << 20, dtype=np.uint8).tobytes()
+    with path.open("wb") as f:
+        f.write(struct.pack("<Q", len(header)))
+        f.write(header)
+        for _ in range(mib):
+            f.write(block)
+        f.flush()
+        os.fsync(f.fileno())
+
+
+def digest(path):
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for block in iter(lambda: f.read(1 << 20), b""):
+            h.update(block)
+    return h.hexdigest()
+
+
+def residents(shard):
+    if platform.system() != "Linux":
+        return None
+    address = np.frombuffer(shard._mm, dtype=np.uint8).ctypes.data
+    count = (len(shard._mm) + mmap.PAGESIZE - 1) // mmap.PAGESIZE
+    vector = (ctypes.c_ubyte * count)()
+    libc = ctypes.CDLL(None, use_errno=True)
+    if libc.mincore(ctypes.c_void_p(address), ctypes.c_size_t(len(shard._mm)), vector):
+        error = ctypes.get_errno()
+        raise OSError(error, os.strerror(error))
+    return sum(bool(x & 1) for x in vector)
+
+
+def cold_own_file(shard):
+    shard._mm.madvise(mmap.MADV_DONTNEED)
+    os.posix_fadvise(shard._file.fileno(), 0, 0, os.POSIX_FADV_DONTNEED)
+
+
+def timed(fn, loops):
+    start = time.perf_counter_ns()
+    for _ in range(loops):
+        fn()
+    return (time.perf_counter_ns() - start) / loops
+
+
+def paired(name, baseline, candidate, repeats, loops, rng, prepare=None):
+    # Randomized AB/BA pairs; no benchmark threshold is used in unit tests.
+    timings = []
+    for _ in range(repeats):
+        pair = {}
+        for side in rng.permutation(["baseline", "candidate"]):
+            if prepare is not None:
+                prepare()
+            pair[str(side)] = timed(baseline if side == "baseline" else candidate, loops)
+        timings.append(pair)
+    old = np.array([x["baseline"] for x in timings])
+    new = np.array([x["candidate"] for x in timings])
+    paired_reduction = 1 - new / old
+    bootstrap = np.median(paired_reduction[rng.integers(0, repeats, (5000, repeats))], axis=1)
+    return {"name": name, "pairs": repeats, "loops_per_sample": loops,
+            "baseline_median_ms": float(np.median(old) / 1e6),
+            "candidate_median_ms": float(np.median(new) / 1e6),
+            "median_paired_time_reduction": float(np.median(paired_reduction)),
+            "paired_reduction_bootstrap_95pct": np.quantile(bootstrap, [0.025, 0.975]).tolist(),
+            "samples_ns": timings}
+
+
+def peak_allocation(fn):
+    tracemalloc.start()
+    fn()
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    return peak
+
+
+def run(args):
+    rng = np.random.default_rng(args.seed)
+    with tempfile.TemporaryDirectory(prefix="edge0-pagewarm-", dir=args.directory) as td:
+        path = Path(td) / "fixture.safetensors"
+        write_fixture(path, args.mib)
+        before = digest(path)
+        shard = module.SafetensorsMmap(str(path))
+        try:
+            ranges = [(name, expert, 4) for expert in range(4)
+                      for name in shard.entries if name != "filler"]
+            legacy_seq_read(shard)
+            results = [
+                paired("resident whole-shard warmup", lambda: legacy_seq_read(shard),
+                       shard.seq_read, args.repeats, args.loops, rng),
+                paired("resident four-expert warmup", lambda: legacy_expert_warm(shard, ranges),
+                       lambda: page_expert_warm(shard, ranges), args.repeats, args.loops, rng),
+            ]
+            allocation = {"baseline_peak_traced_bytes": peak_allocation(lambda: legacy_seq_read(shard)),
+                          "candidate_peak_traced_bytes": peak_allocation(shard.seq_read)}
+            residency = {}
+            for name, fn in (("baseline", lambda: legacy_seq_read(shard)), ("candidate", shard.seq_read)):
+                if hasattr(shard._mm, "madvise") and hasattr(mmap, "MADV_DONTNEED"):
+                    shard._mm.madvise(mmap.MADV_DONTNEED)
+                fn()
+                residency[name] = residents(shard)
+            if args.cold:
+                if platform.system() != "Linux" or not hasattr(os, "posix_fadvise"):
+                    raise RuntimeError("--cold requires Linux posix_fadvise")
+                cold_details = []
+                def prepare():
+                    cold_own_file(shard)
+                    cold_details.append({"resident_pages_before": residents(shard)})
+                results.append(paired("cold file-page-cache whole-shard warmup",
+                                      lambda: legacy_seq_read(shard), shard.seq_read,
+                                      args.repeats, 1, rng, prepare))
+                # prepare() is outside timing; preserve each precondition.
+                results[-1]["preconditions_in_execution_order"] = cold_details
+            total = len(shard._mm)
+            result = {"schema": 1, "python": platform.python_version(), "numpy": np.__version__,
+                      "system": platform.system(), "machine": platform.machine(),
+                      "page_bytes": mmap.PAGESIZE, "fixture_bytes": total,
+                      "fixture_sha256": before, "fixture_unchanged": digest(path) == before,
+                      "fixture_kind": "synthetic safetensors with checkpoint-sized expert byte spans",
+                      "source_sha256": hashlib.sha256(SOURCE.read_bytes()).hexdigest(),
+                      "legacy_reference_revision": "fbab5f8c08e843e204c0fc6ae18b89a154c652cf",
+                      "seed": args.seed, "resident_pages_after_warmup": residency,
+                      "total_mapped_pages": (total + mmap.PAGESIZE - 1) // mmap.PAGESIZE,
+                      "allocation": allocation, "benchmarks": results,
+                      "scope": "Host warming latency and traced temporary allocation only. No token-rate, model-quality, disk-bandwidth, GPU, or iPhone claim. Cold means this temporary file's OS page cache; storage-controller caches are not flushed."}
+        finally:
+            shard.close()
+    return result
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--mib", type=int, default=128)
+    p.add_argument("--repeats", type=int, default=21)
+    p.add_argument("--loops", type=int, default=5)
+    p.add_argument("--seed", type=int, default=20260910)
+    p.add_argument("--directory", type=Path, help="temporary fixture directory on the drive under test")
+    p.add_argument("--cold", action="store_true")
+    p.add_argument("--json", type=Path)
+    a = p.parse_args()
+    if not 7 <= a.mib <= 4096 or a.repeats < 3 or a.loops < 1:
+        p.error("require 7..4096 MiB, at least 3 pairs, and at least 1 loop")
+    result = run(a)
+    text = json.dumps(result, indent=2) + "\n"
+    if a.json:
+        a.json.parent.mkdir(parents=True, exist_ok=True)
+        a.json.write_text(text)
+    print(text)

--- a/scripts/bench_page_warmup_mlx.py
+++ b/scripts/bench_page_warmup_mlx.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Exact real-weight smoke and paired warm/materialize benchmark.
+
+Uses nine pinned Edge0 experts fetched by fetch_pagewarm_samples.py.
+Pass --cpu-eager for CPU validation without the MLX JIT. This benchmark
+measures explicit warming plus materialization, not full-model token rate.
+"""
+from pathlib import Path
+import argparse
+import hashlib, json, sys, tempfile, time
+import numpy as np
+from safetensors.numpy import save_file
+
+ROOT=Path(__file__).resolve().parents[1]
+sys.path.insert(0,str(ROOT/'src'))
+parser=argparse.ArgumentParser(description=__doc__)
+parser.add_argument('--samples', type=Path, required=True)
+parser.add_argument('--json', type=Path, required=True)
+parser.add_argument('--cpu-eager', action='store_true')
+args=parser.parse_args()
+args.json.parent.mkdir(parents=True, exist_ok=True)
+import mlx.core as mx
+if args.cpu_eager:
+    mx.set_default_device(mx.cpu)
+    mx.disable_compile()
+from edge0.streaming.layer import StreamingSwitchGLU
+from edge0.streaming.mmap import SafetensorsMmap
+from edge0.streaming.options import LayerOptions
+from edge0.moe.spec import MoESpec, QuantSpec
+
+sample=args.samples
+mf=json.loads((sample/'manifest.json').read_text())
+pairs=sorted({(r['layer'],r['expert']) for r in mf['samples']})
+tensors={}
+for proj in ('gate_proj','up_proj','down_proj'):
+    for part in ('weight','scales','biases'):
+        arrays=[]
+        for layer,expert in pairs:
+            r=next(r for r in mf['samples'] if (r['layer'],r['expert'],r['projection'],r['part'])==(layer,expert,proj,part))
+            data=(sample/r['file']).read_bytes()
+            assert hashlib.sha256(data).hexdigest()==r['sha256']
+            arrays.append(np.frombuffer(data,dtype='<u4' if part=='weight' else '<u2').reshape(r['shape']))
+        tensors[f'layers.0.mlp.switch_mlp.{proj}.{part}']=np.stack(arrays)
+
+def old_warm(lay,experts):
+    for e in experts:
+        for proj in ('gate_proj','up_proj','down_proj'):
+            for part in ('weight','scales','biases'):
+                name=f'{lay._prefix}.{proj}.{part}'
+                raw=lay._shard_for(name).raw(name)
+                per=raw.size//lay.num_experts
+                _=raw[e*per:(e+1)*per].sum()
+
+result={'repo':mf['repo'],'weight_revision':mf['revision'],'sample_experts':[list(p) for p in pairs],'python':sys.version.split()[0],'numpy':np.__version__,'mlx':mx.__version__,'device':str(mx.default_device()),'cpu_eager':args.cpu_eager,'weight_bytes':sum(t.nbytes for t in tensors.values())}
+with tempfile.TemporaryDirectory(prefix='real-pagewarm-',dir=args.json.parent) as td:
+    path=Path(td)/'experts.safetensors'; save_file(tensors,str(path))
+    sha=hashlib.sha256(path.read_bytes()).hexdigest()
+    mm=SafetensorsMmap(str(path))
+    spec=MoESpec(num_experts=len(pairs),top_k=4,intermediate_size=512,quant=QuantSpec(bits=4,group_size=64),key_template='layers.{layer}.mlp.switch_mlp',block_path='layers.{layer}.mlp.switch_mlp')
+    options=LayerOptions(use_compile=False,load_threads=1,prefetch_threads=1)
+    layer=StreamingSwitchGLU([mm],0,spec,options)
+    # Independent snapshots of every materialized tensor before/after warming.
+    before={}
+    for e in range(len(pairs)):
+        bundle=layer._build(e); mx.eval(*bundle.values())
+        before[e]={k:np.asarray(v.view(mx.uint16) if v.dtype==mx.bfloat16 else v).copy() for k,v in bundle.items()}
+    layer.warm_pages(range(len(pairs))); mm.seq_read()
+    tensor_checks=0
+    for e in range(len(pairs)):
+        bundle=layer._build(e); mx.eval(*bundle.values())
+        for k,v in bundle.items():
+            current=np.asarray(v.view(mx.uint16) if v.dtype==mx.bfloat16 else v)
+            assert np.array_equal(current,before[e][k]); tensor_checks+=1
+    result['materialized_tensors_exact']=tensor_checks
+    # Same actual quantized gather/SwiGLU path before and after warming.
+    rng=np.random.default_rng(10913)
+    equal_outputs=0
+    for i in range(12):
+        x=mx.array(rng.normal(size=(1,1,2048)).astype(np.float16))
+        ids=mx.array(rng.choice(len(pairs),size=(1,4),replace=False).astype(np.int32))
+        a=layer(x,ids); mx.eval(a)
+        layer.warm_pages(range(len(pairs)))
+        b=layer(x,ids); mx.eval(b)
+        assert mx.array_equal(a,b).item(); equal_outputs+=1
+    result['exact_swiglu_output_checks']=equal_outputs
+    selected=[0,3,5,8]
+    def work(warm):
+        warm(layer,selected)
+        bundles=[layer._build(e) for e in selected]
+        mx.eval(*[v for b in bundles for v in b.values()])
+    # Direct materialization avoids claiming any cache hit as a build gain.
+    work(old_warm); work(lambda l,e:l.warm_pages(e))
+    rows=[]
+    for trial in range(31):
+        row={}
+        for side in rng.permutation(['baseline','candidate']):
+            fn=old_warm if side=='baseline' else lambda l,e:l.warm_pages(e)
+            start=time.perf_counter_ns()
+            for _ in range(3): work(fn)
+            row[str(side)]=(time.perf_counter_ns()-start)/3
+        rows.append(row)
+    a=np.array([r['baseline'] for r in rows]); b=np.array([r['candidate'] for r in rows]); reductions=1-b/a
+    boot=np.median(reductions[rng.integers(0,len(rows),(5000,len(rows)))],axis=1)
+    result['warm_and_materialize']={'pairs':31,'loops':3,'selected_experts':selected,'baseline_median_ms':float(np.median(a)/1e6),'candidate_median_ms':float(np.median(b)/1e6),'median_paired_time_reduction':float(np.median(reductions)),'bootstrap_95pct':np.quantile(boot,[0.025,0.975]).tolist(),'samples_ns':rows}
+    result['file_unchanged']=hashlib.sha256(path.read_bytes()).hexdigest()==sha
+    result['scope']='Actual materialization of nine published experts and 12 exact SwiGLU output comparisons with synthetic inputs. Paired latency covers explicit page warming followed by four expert builds and MLX eval. It is not full-model inference, token throughput, or an end-to-end quality benchmark.'
+    layer.close(); del bundle,before,tensors
+    mm.close()
+out=args.json
+out.write_text(json.dumps(result,indent=2)+'\n')
+print(json.dumps({k:v for k,v in result.items() if k!='warm_and_materialize'},indent=2))
+print(json.dumps({k:v for k,v in result['warm_and_materialize'].items() if k!='samples_ns'},indent=2))

--- a/scripts/fetch_pagewarm_samples.py
+++ b/scripts/fetch_pagewarm_samples.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Fetch a small, pinned subset of public Edge0 weights with verified HTTP ranges.
+Never downloads a full checkpoint. Only the declared public byte ranges are fetched.
+"""
+from pathlib import Path
+import argparse
+import hashlib, json, struct
+import requests
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument('--out', type=Path, default=Path('edge0-samples'))
+OUT = parser.parse_args().out
+OUT.mkdir(parents=True, exist_ok=True)
+REPO='Edge0/Edge0-35B-A3B-preview'
+REV='1ff9f4478890faec0368c5463b621d1036d5b518'
+ROOT=f'https://huggingface.co/{REPO}/resolve/{REV}/'
+S=requests.Session()
+
+def get_json(name):
+    p=OUT/name
+    if p.exists(): return json.loads(p.read_text())
+    r=S.get(ROOT+name,timeout=30); r.raise_for_status()
+    j=r.json(); p.write_text(json.dumps(j,indent=2)); return j
+
+def byte_range(name,start,length):
+    # A range-specific query prevents a proxy from replaying a different cached range.
+    u=ROOT+name+f'?sc_range={start}-{start+length-1}'
+    with S.get(u,headers={'Range':f'bytes={start}-{start+length-1}'},timeout=40,stream=True) as r:
+        r.raise_for_status()
+        expected=f'bytes {start}-{start+length-1}/'
+        if r.status_code!=206 or not r.headers.get('Content-Range','').startswith(expected):
+            raise RuntimeError(f'Host did not honor requested range: {r.status_code} {r.headers.get("Content-Range")}')
+        data=r.raw.read(length+1)
+        if len(data)!=length: raise RuntimeError(f'Incorrect range size: {len(data)} != {length}')
+        return data
+
+index=get_json('model.safetensors.index.json')
+get_json('config.json')
+headers={}
+ledger=[]
+# Fixed layers/experts selected before inspecting values. Total payload is under 20 MB.
+for layer in (0,20,39):
+    for expert in (0,127,255):
+        for proj in ('gate_proj','up_proj','down_proj'):
+            for part in ('weight','scales','biases'):
+                key=f'language_model.model.layers.{layer}.mlp.switch_mlp.{proj}.{part}'
+                shard=index['weight_map'][key]
+                if shard not in headers:
+                    hp=OUT/(shard+'.header.json')
+                    if hp.exists():
+                        saved=json.loads(hp.read_text()); hlen=saved['header_bytes']; header=saved['tensors']
+                    else:
+                        hlen=struct.unpack('<Q',byte_range(shard,0,8))[0]
+                        if hlen>16*1024*1024: raise RuntimeError('Unexpected large tensor header')
+                        header=json.loads(byte_range(shard,8,hlen))
+                        hp.write_text(json.dumps({'header_bytes':hlen,'tensors':header},indent=2))
+                    headers[shard]=(hlen,header)
+                hlen,header=headers[shard]
+                t=header[key]; shape=t['shape']; start,stop=t['data_offsets']
+                if shape[0]!=256 or (stop-start)%256: raise RuntimeError('Unexpected expert layout')
+                size=(stop-start)//256; offset=8+hlen+start+expert*size
+                filename=f'L{layer:02d}_E{expert:03d}_{proj}_{part}.bin'
+                p=OUT/filename
+                if not p.exists(): p.write_bytes(byte_range(shard,offset,size))
+                data=p.read_bytes()
+                if len(data)!=size: raise RuntimeError(f'Invalid cached payload {p}')
+                ledger.append({'layer':layer,'expert':expert,'projection':proj,'part':part,'key':key,'shard':shard,'range_start':offset,'bytes':size,'dtype':t['dtype'],'shape':shape[1:],'file':filename,'sha256':hashlib.sha256(data).hexdigest()})
+        print(f'SAMPLED layer={layer} expert={expert}',flush=True)
+        (OUT/'manifest.json').write_text(json.dumps({'repo':REPO,'revision':REV,'samples':ledger},indent=2))
+print(json.dumps({'experts':9,'payload_bytes':sum(x['bytes'] for x in ledger),'manifest':str(OUT/'manifest.json')},indent=2))

--- a/src/edge0/streaming/layer.py
+++ b/src/edge0/streaming/layer.py
@@ -380,10 +380,10 @@ class StreamingSwitchGLU:
             for proj in ("gate_proj", "up_proj", "down_proj"):
                 for part in ("weight", "scales", "biases"):
                     name = f"{self._prefix}.{proj}.{part}"
-                    raw = self._shard_for(name).raw(name)
-                    per = raw.size // self.num_experts
-                    sl = raw[e * per:(e + 1) * per]
-                    _ = sl.sum()
+                    shard = self._shard_for(name)
+                    entry = shard.entries[name]
+                    per = entry["size"] // self.num_experts
+                    shard.touch(entry["offset"] + e * per, per)
 
     def _get_bundles(self, experts):
         """Resolve bundles: pinned/LRU hits synchronously, misses via pool."""

--- a/src/edge0/streaming/mmap.py
+++ b/src/edge0/streaming/mmap.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import mmap
+import operator
 import struct
 
 import numpy as np
@@ -49,15 +50,48 @@ class SafetensorsMmap:
         except Exception:  # noqa: BLE001 — advisory only
             pass
 
-    def seq_read(self, chunk: int = 1 << 24):
-        """Force every page resident: one sequential pass over the shard.
+    def touch(self, offset: int = 0, length: int | None = None):
+        """Synchronously read one byte per OS page in a mapped byte range.
 
-        macOS madvise only warms roughly half the file, so a full read is
-        the reliable way to remove per-expert page-fault cost from the
-        first request."""
+        ``offset`` is absolute within the shard (including the header).
+        No payload copy or persistent ndarray is created. Reading the first
+        byte, then each subsequent page boundary, also covers unaligned
+        ranges and a final partial page. Residency can still change under
+        OS memory pressure after this call returns.
+        """
+        offset = operator.index(offset)
+        total = len(self._mm)
+        if not 0 <= offset <= total:
+            raise ValueError("offset is outside the mapped shard")
+        length = total - offset if length is None else operator.index(length)
+        if length < 0 or length > total - offset:
+            raise ValueError("length is outside the mapped shard")
+        if length == 0:
+            return
+
+        end = offset + length
+        _ = self._mm[offset]
+        first_boundary = offset + mmap.PAGESIZE - offset % mmap.PAGESIZE
+        if first_boundary < end:
+            # A strided NumPy reduction performs the remaining reads in C.
+            # The view ends at `end`, so no byte outside the range is read.
+            raw = np.frombuffer(
+                self._mm, dtype=np.uint8,
+                count=end - first_boundary, offset=first_boundary)
+            _ = raw[::mmap.PAGESIZE].sum(dtype=np.uint64)
+
+    def seq_read(self, chunk: int = 1 << 24):
+        """Fault each mapped page without allocating chunk-sized byte copies.
+
+        ``chunk`` remains the traversal window size. Use the actual OS
+        page size for reads within each window, including partial windows.
+        """
+        chunk = operator.index(chunk)
+        if chunk <= 0:
+            raise ValueError("chunk must be positive")
         total = len(self._mm)
         for off in range(0, total, chunk):
-            _ = self._mm[off:off + chunk]
+            self.touch(off, min(chunk, total - off))
 
     def raw(self, name: str) -> np.ndarray:
         e = self.entries[name]

--- a/tests/test_streaming_math.py
+++ b/tests/test_streaming_math.py
@@ -299,3 +299,35 @@ def test_double_buffered_swap(layer):
         ref2 = lay(x, mx.array([second], dtype=mx.int32))
         assert mx.allclose(out1, ref1).item()
         assert mx.allclose(out2, ref2).item()
+
+
+def test_warm_pages_selects_only_requested_expert_ranges(layer, monkeypatch):
+    lay, mm, _ = layer
+    calls = []
+    monkeypatch.setattr(mm, "touch", lambda offset, length: calls.append((offset, length)))
+    selected = [0, N_EXPERTS - 1]
+    lay.warm_pages(selected)
+    expected = []
+    for expert in selected:
+        for proj in ("gate_proj", "up_proj", "down_proj"):
+            for part in ("weight", "scales", "biases"):
+                entry = mm.entries[f"layers.0.mlp.switch_mlp.{proj}.{part}"]
+                per = entry["size"] // N_EXPERTS
+                expected.append((entry["offset"] + expert * per, per))
+    assert calls == expected
+    calls.clear()
+    lay.warm_pages([])
+    assert calls == []
+
+
+def test_warm_pages_preserves_exact_outputs(layer):
+    lay, mm, _ = layer
+    x = mx.random.normal((1, 2, DIM)).astype(mx.float16)
+    inds = _inds(tokens=2)
+    before = lay(x, inds)
+    mx.eval(before)
+    lay.warm_pages(range(N_EXPERTS))
+    mm.seq_read()
+    after = lay(x, inds)
+    mx.eval(after)
+    assert mx.array_equal(before, after).item()

--- a/tests/test_streaming_mmap.py
+++ b/tests/test_streaming_mmap.py
@@ -1,0 +1,175 @@
+"""Page-warming contracts, runnable with NumPy + pytest and no MLX.
+
+Load the backend-free source directly: edge0.streaming.__init__ imports
+its MLX layer, which is intentionally unnecessary for these I/O tests.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import struct
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+_SOURCE = Path(__file__).resolve().parents[1] / "src/edge0/streaming/mmap.py"
+_SPEC = importlib.util.spec_from_file_location("edge0_mmap_under_test", _SOURCE)
+mmap_module = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(mmap_module)
+SafetensorsMmap = mmap_module.SafetensorsMmap
+
+
+def write_shard(path, size=100003):
+    payload = np.random.default_rng(73).integers(0, 256, size, dtype=np.uint8)
+    header = json.dumps({
+        "w": {"dtype": "U8", "shape": [size], "data_offsets": [0, size]},
+        "empty": {"dtype": "U8", "shape": [0], "data_offsets": [size, size]},
+    }).encode()
+    path.write_bytes(struct.pack("<Q", len(header)) + header + payload.tobytes())
+    return payload
+
+
+@pytest.fixture
+def shard(tmp_path):
+    path = tmp_path / "weights.safetensors"
+    payload = write_shard(path)
+    mapped = SafetensorsMmap(str(path))
+    yield mapped, path, payload
+    mapped.close()
+
+
+def test_warming_preserves_bytes_and_raw_readonly_contract(shard):
+    mapped, path, payload = shard
+    before = path.read_bytes()
+    assert mapped.touch() is None
+    assert mapped.touch(len(before), 0) is None
+    mapped.seq_read()
+    mapped.seq_read(7919)
+    raw = mapped.raw("w")
+    np.testing.assert_array_equal(raw, payload)
+    assert not raw.flags.writeable
+    assert not raw.flags.owndata
+    assert mapped.raw("empty").size == 0
+    assert path.read_bytes() == before
+    del raw  # no outstanding buffer when the fixture closes the mmap
+
+
+@pytest.mark.parametrize("offset,length", [(-1, 0), (10**9, 0), (0, -1),
+                                           (0, 10**9), (100000, 100000)])
+def test_out_of_range_rejected(shard, offset, length):
+    with pytest.raises(ValueError):
+        shard[0].touch(offset, length)
+
+
+@pytest.mark.parametrize("offset,length", [(0.5, 1), (0, 1.5)])
+def test_noninteger_ranges_rejected(shard, offset, length):
+    with pytest.raises(TypeError):
+        shard[0].touch(offset, length)
+
+
+@pytest.mark.parametrize("chunk", [0, -1, -4096])
+def test_nonpositive_chunks_rejected(shard, chunk):
+    with pytest.raises(ValueError):
+        shard[0].seq_read(chunk)
+
+
+def test_numpy_integer_arguments(shard):
+    shard[0].touch(np.int64(3), np.int64(71))
+    shard[0].seq_read(np.int64(7919))
+
+
+class ReadTrace:
+    """Instrument both scalar mmap reads and strided NumPy consumption."""
+
+    def __init__(self, length):
+        self.length = length
+        self.reads = []
+
+    def __len__(self):
+        return self.length
+
+    def __getitem__(self, index):
+        # A slice here would be a payload-sized bytes copy.
+        assert isinstance(index, int)
+        assert 0 <= index < self.length
+        self.reads.append(index)
+        return 0
+
+    def frombuffer(self, buffer, *, dtype, count, offset):
+        assert buffer is self
+        assert dtype == np.uint8
+        assert 0 <= offset <= offset + count <= self.length
+        owner = self
+
+        class View:
+            def __init__(self, positions):
+                self.positions = positions
+
+            def __getitem__(self, key):
+                return View(self.positions[key])
+
+            def sum(self, dtype):
+                assert dtype == np.uint64
+                owner.reads.extend(self.positions)
+                return 0
+
+        return View(range(offset, offset + count))
+
+
+def traced_shard(monkeypatch, page_size, length):
+    trace = ReadTrace(length)
+    mapped = object.__new__(SafetensorsMmap)
+    mapped._mm = trace
+    # Replace only the module-local namespaces, not global NumPy/mmap.
+    monkeypatch.setattr(mmap_module, "mmap", SimpleNamespace(PAGESIZE=page_size))
+    monkeypatch.setattr(mmap_module, "np", SimpleNamespace(
+        frombuffer=trace.frombuffer, uint8=np.uint8, uint64=np.uint64))
+    return mapped, trace
+
+
+@pytest.mark.parametrize("page_size", [4096, 16384])
+def test_exact_page_coverage_including_unaligned_tail(monkeypatch, page_size):
+    total = 11 * page_size + 37
+    mapped, trace = traced_shard(monkeypatch, page_size, total)
+    cases = [(0, 0), (total, 0), (0, total), (page_size - 1, 2),
+             (page_size - 1, page_size + 2), (3, page_size),
+             (page_size, page_size), (total - 1, 1)]
+    rng = np.random.default_rng(91)
+    for _ in range(1000):
+        start = int(rng.integers(total + 1))
+        cases.append((start, int(rng.integers(total - start + 1))))
+    for start, length in cases:
+        trace.reads.clear()
+        mapped.touch(start, length)
+        expected = (set(range(start // page_size,
+                              (start + length - 1) // page_size + 1))
+                    if length else set())
+        actual = [address // page_size for address in trace.reads]
+        assert set(actual) == expected
+        assert len(actual) == len(expected), "must read exactly once per page"
+        assert all(start <= address < start + length for address in trace.reads)
+
+
+@pytest.mark.parametrize("page_size", [4096, 16384])
+@pytest.mark.parametrize("chunk_kind", ["small", "unaligned", "page", "large"])
+def test_seq_read_covers_all_pages_without_copy(monkeypatch, page_size, chunk_kind):
+    chunks = {"small": 97, "unaligned": page_size - 1,
+              "page": page_size, "large": 1 << 24}
+    total = 5 * page_size + 13
+    mapped, trace = traced_shard(monkeypatch, page_size, total)
+    mapped.seq_read(chunks[chunk_kind])
+    assert {a // page_size for a in trace.reads} == set(range(6))
+    assert all(0 <= a < total for a in trace.reads)
+
+
+def test_close_has_no_retained_numpy_views(tmp_path):
+    path = tmp_path / "weights.safetensors"
+    write_shard(path)
+    mapped = SafetensorsMmap(str(path))
+    for _ in range(10):
+        mapped.touch(3, 99997)
+        mapped.seq_read(8191)
+    mapped.close()  # would raise BufferError if a warming view escaped
+    assert mapped._file.closed


### PR DESCRIPTION
## Summary

Reduce host-side mmap warming work without changing model weights, routing, cache policy, quantization, or inference arithmetic.

- Add `SafetensorsMmap.touch(offset, length)`: read exactly one byte per intersecting OS page, using `mmap.PAGESIZE`, with unaligned-tail and empty-range handling.
- Replace `seq_read()` chunk-sized byte copies with page reads while preserving its traversal-window argument.
- Replace the ignored full-byte sums in `StreamingSwitchGLU.warm_pages()` with exact expert-range page reads.
- Add backend-free page-coverage tests, MLX integration checks, paired benchmarks, and raw results. Linux CI runs the new backend-free tests.

The relevant entry points are explicit expert warming and Ling's `EDGE0_PREWARM=1` startup path. This is a warming/preparation optimization, not a claimed decoder-token-rate or model-capacity gain.

## Measured improvement

Intel i5-3470 Linux host, 4 KiB pages, Python 3.12.13, NumPy 2.5.3. Comparisons randomize baseline/candidate order within each pair against the implementations at `fbab5f8c08e843e204c0fc6ae18b89a154c652cf`.

| Path | Baseline median | Candidate median |
|---|---:|---:|
| Resident 128 MiB shard warming | 29.731 ms | 0.481 ms |
| Resident 512 MiB shard warming | 75.361 ms | 1.971 ms |
| Explicit warming + four real expert builds + MLX CPU evaluation | 5.593 ms | 1.767 ms |
| Default warming's peak traced allocation | 33,554,602 bytes | 34,352 bytes |

The real-weight preparation test has 31 randomized pairs and a median paired time reduction of **68.38%**, bootstrap 95% interval **68.20%–68.53%**. A separate-process reproduction measured 73.89%; both raw runs are included.

Cold-file-page-cache controls show **no clear speed advantage**: the 128 MiB paired interval is [-2.65%, +0.37%], and the 512 MiB interval is [-7.05%, +11.44%]. All cold samples begin at zero resident pages, checked with Linux `mincore`. Only the benchmark's own temporary file is evicted. The result does not imply less physical disk traffic.

## Correctness

- Instrumented execution verifies exact page coverage for 4 KiB and 16 KiB pages, with 1,000 random ranges per page size plus boundary cases.
- Both whole-shard paths leave all 32,769 / 131,073 fixture pages resident, with unchanged input SHA-256.
- 81 materialized tensors from nine published Edge0 experts match byte-for-byte before/after warming.
- 12 real-expert SwiGLU comparisons with synthetic inputs match exactly.
- Backend-free mmap/hygiene tests: **27 passed**.
- Full suite with pinned MLX 0.30.4 / MLX-LM 0.31.0 on CPU eager execution: **87 passed, 1 skipped, 2 slow tests deselected**. Matched upstream: 60 passed, 1 skipped, 2 deselected.

On this host, GCC 15 rejects duplicate floating-point typedefs in MLX 0.30.4's bundled CPU JIT preamble. The same 14 streaming-math failures occur on unchanged upstream. Successful CPU tests disable compilation in the test harness only. Production compilation and dependency pins are unchanged; the existing macOS CI remains the compiled/Metal validation path.

## Reproduction

See `docs/benchmarks/page-warmup.md`, `scripts/bench_page_warmup.py`, and the optional small real-weight probe. The real-weight downloader fetches about 16 MB of pinned public ranges, not the complete checkpoint. Raw timing samples and controls are in `docs/benchmarks/page-warmup/`.
