### PR TITLE
Fix/35b nan hidden clip

### DIFF
--- a/src/edge0/backends/mlx/_impl/qwen3_5.py
+++ b/src/edge0/backends/mlx/_impl/qwen3_5.py
@@ -6,8 +6,10 @@
 # mlx_lm package, sibling model files point at this vendored package so
 # the prerouter block patch lands on OUR ``Qwen3NextSparseMoeBlock``;
 # (2) ``Qwen3_5TextModel.__call__`` gained the edge0 engine callback
-# hooks (before/after_layer_cb + async_eval_per_layer).
+# hooks (before/after_layer_cb + async_eval_per_layer) plus the
+# hidden-state clip / NaN scrub (``QWEN_HIDDEN_CLIP``).
 
+import os
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Union
 
@@ -272,11 +274,23 @@ class Qwen3_5TextModel(nn.Module):
         fa_mask = create_attention_mask(hidden_states, cache[self.fa_idx])
         ssm_mask = create_ssm_mask(hidden_states, cache[self.ssm_idx])
 
+        # Hidden-state clip (QWEN_HIDDEN_CLIP, e.g. 1000): clamps each
+        # layer's output to [-v, +v] and zeroes NaN entries so a single
+        # fp16 overflow inside one layer cannot poison the whole network
+        # (edge0-35b: prefill overflow at layer 10 -> layers 11+ all-NaN ->
+        # all-NaN logits -> argmax falls back to token 0 ('!') collapse).
+        # Off by default, enabled by the engine (parity with the ling
+        # LING_HIDDEN_CLIP fix).
+        _clip_v = float(os.environ.get("QWEN_HIDDEN_CLIP", "0"))
         for li, (layer, c) in enumerate(zip(self.layers, cache)):
             if before_layer_cb is not None:
                 before_layer_cb(li)
             mask = ssm_mask if layer.is_linear else fa_mask
             hidden_states = layer(hidden_states, mask=mask, cache=c)
+            if _clip_v > 0:
+                hidden_states = mx.where(
+                    mx.isnan(hidden_states), mx.zeros_like(hidden_states),
+                    mx.clip(hidden_states, -_clip_v, _clip_v))
             if after_layer_cb is not None:
                 after_layer_cb(li, hidden_states)
             if async_eval_per_layer:

--- a/src/edge0/engine/qwen.py
+++ b/src/edge0/engine/qwen.py
@@ -14,6 +14,8 @@ Port of the deployment's ``engine_qwen.py`` trained-prerouter path:
 
 from __future__ import annotations
 
+import os
+
 from edge0.backends import core
 
 from edge0.backends.mlx._impl.qwen3_5_moe import Model as Qwen35Model
@@ -85,6 +87,16 @@ class Qwen35Engine(Edge0Engine):
     """Streaming Qwen3.5-MoE engine (staged decode + trained prerouter)."""
 
     name = "edge0-35b"
+
+    def __init__(self, model_dir: str, cfg, tokenizer=None):
+        # NAN_BANG_COLLAPSE_FIX parity (engine/ling.py): hidden clip default
+        # 1000 unless the deployer overrides QWEN_HIDDEN_CLIP explicitly.
+        # One fp16 overflow inside a layer otherwise poisons the whole net
+        # into all-NaN logits -> argmax fallback token 0 ('!') collapse,
+        # which does not recover until the process restarts.
+        if "QWEN_HIDDEN_CLIP" not in os.environ:
+            os.environ["QWEN_HIDDEN_CLIP"] = "1000"
+        super().__init__(model_dir, cfg, tokenizer=tokenizer)
 
     def _build(self):
         cfg = self.cfg

--- a/src/edge0/server/chat.py
+++ b/src/edge0/server/chat.py
@@ -88,21 +88,33 @@ class ChatSession:
             # renders the canonical no-think prompt — an EMPTY think
             # block closer, the model's direct-answer form.  Default OFF
             # (CLI demo parity).
+            #
+            # The successful render MUST be kept: substituting the
+            # hardcoded ChatML drops that think-block closer, the model
+            # then opens its own <think> and the turn derails (issue #11:
+            # <think> leaking into content, then empty/garbled replies).
+            # ``_chat_text()`` is a last resort, never the success path.
+            msgs = [m.__dict__ for m in self.req.messages]
             think = self.req.enable_thinking
             if think is None:
                 think = False
             try:
                 text = tok.apply_chat_template(
-                    [m.__dict__ for m in self.req.messages],
-                    tokenize=False, add_generation_prompt=True,
+                    msgs, tokenize=False, add_generation_prompt=True,
                     enable_thinking=bool(think))
             except TypeError:
                 # tokenizer template without the kwarg: plain render
-                text = tok.apply_chat_template(
-                    [m.__dict__ for m in self.req.messages],
-                    tokenize=False, add_generation_prompt=True)
-            else:
+                try:
+                    text = tok.apply_chat_template(
+                        msgs, tokenize=False, add_generation_prompt=True)
+                except Exception:  # noqa: BLE001
+                    text = self._chat_text()
+            except Exception:  # noqa: BLE001 — render failed: last resort
                 text = self._chat_text()
+        else:
+            # Tokenizer without a chat template: plain ChatML.  (This also
+            # used to leave ``text`` unbound -> NameError.)
+            text = self._chat_text()
         ids = tok.encode(text)
         if not ids:
             ids = [tok.bos_token_id or 0]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -47,6 +47,7 @@ class FakeTok:
     def __init__(self, ids=(7, 8, 9)):
         self.ids = list(ids)
         self.bos_token_id = 0
+        self.encoded_text = None
 
     def apply_chat_template(self, messages, tokenize=False,
                             add_generation_prompt=True,
@@ -57,24 +58,31 @@ class FakeTok:
         return text
 
     def encode(self, text):
+        self.encoded_text = text
         return self.ids
 
     def decode(self, tokens):
         return "".join(f"T{t}" for t in tokens)
 
 
-class PlainTok(FakeTok):
+class PlainTok:
     """Tokenizer without apply_chat_template (stdlib fallback path).
 
-    Deleting the method (vs raising) keeps hasattr() False so the
-    server's plain-text fallback renders instead."""
+    A standalone class rather than a FakeTok subclass: deleting the
+    inherited method off the instance does not work, so ``hasattr`` would
+    stay True and the fallback would never be exercised."""
 
-    def __init__(self):
-        super().__init__()
-        try:
-            del self.apply_chat_template
-        except AttributeError:
-            pass
+    def __init__(self, ids=(7, 8, 9)):
+        self.ids = list(ids)
+        self.bos_token_id = 0
+        self.encoded_text = None
+
+    def encode(self, text):
+        self.encoded_text = text
+        return self.ids
+
+    def decode(self, tokens):
+        return "".join(f"T{t}" for t in tokens)
 
 
 class FakeEngine:
@@ -172,6 +180,12 @@ def test_chat_session_prompt_ids_uses_template():
     sess = ChatSession(eng, _req())
     ids = sess.prompt_ids()
     assert ids == [7, 8, 9]
+    # What actually gets encoded is the RENDERED template, not the
+    # hardcoded ChatML (issue #11: the latter loses the template's empty
+    # <think></think> closer and derails the turn).
+    assert eng._tok.encoded_text.startswith("<tpl>")
+    assert eng._tok.encoded_text.endswith("<|im_start|>assistant\n")
+    assert eng._tok.encoded_text != sess._chat_text()
     # The template was called with enable_thinking=False (serve.py parity).
     text = eng._tok.apply_chat_template([{"role": "user", "content": "hi"}])
     assert "<|im_start|>assistant" in text
@@ -182,6 +196,9 @@ def test_chat_session_prompt_ids_fallback_text():
     sess = ChatSession(eng, _req())
     ids = sess.prompt_ids()
     assert ids == [7, 8, 9]
+    # No template on the tokenizer -> hardcoded ChatML (this path used to
+    # raise NameError on the unbound ``text``).
+    assert eng._tok.encoded_text == sess._chat_text()
 
 
 def test_chat_session_fallback_text_format():


### PR DESCRIPTION
Fixes #11. Two independent defects — the prompt path that triggered the degenerate turns, and the NaN cascade that made them unrecoverable. Both are needed.

## 1. `ChatSession.prompt_ids` threw away the rendered template (`server/chat.py`)

`try/except/else` was inverted: an `else` clause on `try` runs when **no** exception was raised, so the successful render was discarded and replaced by the hardcoded ChatML from `_chat_text()`.

The qwen35 template ends the generation prompt with an empty think block (`<think>\n\n</think>\n\n` for `enable_thinking=False`); the hardcoded string stops at `<|im_start|>assistant`. The model therefore opened its own `<think>` (leaking into `content`) and some turns derailed into empty or two-token replies — the `!` collapse was the extreme case of that. The render is now kept, and `_chat_text()` is only the fallback for a tokenizer with no template (or a failing render); that also removes the unbound `text` `NameError` on that path.

Regression guard in `tests/test_server.py`: `FakeTok` records the text it is asked to encode, so the assertions check *what is actually encoded* (template vs ChatML), and `PlainTok` is a standalone class — the old `del self.apply_chat_template` raised `AttributeError` on an inherited method and was swallowed, so the fallback path had never been exercised. Both new assertions fail against the old code (`AssertionError` and `UnboundLocalError`).

## 2. All-NaN logits collapsed the answer into `!` (`_impl/qwen3_5.py`, `engine/qwen.py`)

Instrumenting `_forward` on 35b shows the mechanism: a prefill overflow inside one layer (layer 10, a linear-attention layer) leaves 8 of its 15 rows NaN; every later layer then produces all-NaN from that NaN input; the `lm_head` logits are fully NaN (248320 = the whole vocab) and `argmax` falls back to token 0, which decodes to `!` for the rest of the request — and never recovers, because the poisoned state is reused by later requests.

This is the pathology the ling tier already guards with `LING_HIDDEN_CLIP`; the 35b path had no equivalent. It now clamps each layer's output to [-v, +v] and scrubs NaN entries, gated by `QWEN_HIDDEN_CLIP` and defaulted to 1000 by the engine (deployers can override it, or set 0 to disable).

## Verification (Mac mini M4 Pro, `applegpu_g16s`, mlx 0.30.6)

| check | before | after |
|---|---|---|
| the issue's 4-question serve sequence over HTTP | `<think>` leak, then `!` from req3 on | 4/4 fluent, no `<think>` leak |
| 4 questions x 3 rounds through `ChatSession` | collapses | 0 bad of 12 |
| same prompt x6 | collapses | 6/6 ok |
| greedy (temperature 0), the 4 questions | — | all four correct |
| `pytest` | 60 passed / 1 skipped | 60 passed / 1 skipped |
| `pytest -m slow` (real weights, both tiers) | 2 passed | 2 passed |
| greedy token ids, both tiers | baseline | unchanged (the clip only bites on NaN/overflow) |

Note on the `mlx==0.30.4` in the report: on M-series the NAX path is not taken, so the collapse reproduces on 0.30.6 as well — it is not a runtime-version issue.

## Left out on purpose

* Wrong-but-fluent answers at the server's default temperature 0.7 (e.g. `LH is the abbreviation for Linear Harmonic` for LRU) are sampling noise — the same question is correct greedily. Not addressed here.
* `StreamingSwitchGLU.reset()` (`streaming/layer.py:1375`) is documented as the per-request reset but has no caller anywhere in the repository, and neither engine's `_reset_state()` touches the streaming layers. It did not fix this bug when called, so it is left as separate cleanup.
* `mlx-lm==0.31.0` is yanked on PyPI ("Batched KV cache cross contamination"); the pin is untouched here.