### PR TITLE
fix(streaming): stop layer discovery on IndexError too

### DIFF
--- a/src/edge0/streaming/install.py
+++ b/src/edge0/streaming/install.py
@@ -41,7 +41,7 @@ def install_streaming_experts(
         while True:
             try:
                 spec.block_of(model, n)
-            except AttributeError:
+            except (AttributeError, IndexError):  # past the last layer
                 break
             n += 1
         if n == 0:

--- a/tests/test_streaming_math.py
+++ b/tests/test_streaming_math.py
@@ -299,3 +299,33 @@ def test_double_buffered_swap(layer):
         ref2 = lay(x, mx.array([second], dtype=mx.int32))
         assert mx.allclose(out1, ref1).item()
         assert mx.allclose(out2, ref2).item()
+
+
+def test_install_discovers_layer_count(tmp_path):
+    """install_streaming_experts(num_layers=None) probes block_path with
+    increasing layer indices until it stops resolving. Layers live in a
+    list, so running off the end raises IndexError, not AttributeError."""
+    from types import SimpleNamespace
+
+    from edge0.streaming.install import install_streaming_experts
+
+    path = tmp_path / "w.safetensors"
+    _write_shard(path, fuse_gu=False)
+    spec = MoESpec(
+        num_experts=N_EXPERTS, top_k=4, intermediate_size=INTER,
+        quant=QuantSpec(bits=4, group_size=64),
+        layout=WeightLayout.SEPARATE,
+        key_template="layers.{layer}.mlp.switch_mlp",
+        block_path="layers.{layer}.mlp",
+    )
+    moe = SimpleNamespace(switch_mlp=object())
+    model = SimpleNamespace(layers=[SimpleNamespace(mlp=moe),
+                                    SimpleNamespace(mlp=SimpleNamespace()),
+                                    SimpleNamespace(mlp=SimpleNamespace())])
+    twins = install_streaming_experts(
+        model, [SafetensorsMmap(str(path))], spec, options=_options())
+    assert len(twins) == 3
+    assert isinstance(twins[0], StreamingSwitchGLU)
+    assert twins[1] is None and twins[2] is None      # dense layers
+    assert moe.switch_mlp is twins[0]
+    twins[0].close()


### PR DESCRIPTION
`install_streaming_experts(num_layers=None)` counts layers by probing `spec.block_of(model, n)` with increasing `n` until it fails, but it only catches `AttributeError`. Layers live in a list (`MoESpec.block_of` indexes them: "layers are plain lists in most families"), so running off the end raises `IndexError` and the call crashes instead of returning. The shipped engines always pass `num_layers`, which is why it never showed up.

**Fix:** stop on `IndexError` too (one line in `streaming/install.py`).

**Test:** `test_install_discovers_layer_count` installs into a three-layer list-based model (one MoE layer, two dense) with `num_layers=None`. Before: `IndexError: list index out of range` from `spec.py:108`. After: returns `[twin, None, None]`, with the twin swapped into the MoE block. Full suite passes (`pytest`, mlx 0.30.6, Apple M5 Max).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
