### PR TITLE
fix(streaming): give the hot stack its zero overflow row

### DIFF
--- a/src/edge0/streaming/layer.py
+++ b/src/edge0/streaming/layer.py
@@ -327,7 +327,7 @@ class StreamingSwitchGLU:
             b = {}
             for (proj, part), buf in self._hot_backing.items():
                 sh = shape[(proj, part)]
-                per = buf.size // len(self._hot_key)
+                per = buf.size // (len(self._hot_key) + 1)  # + zero row
                 sl = buf[idx * per:(idx + 1) * per]
                 if part == "weight":
                     b[(proj, part)] = core.array(
@@ -984,7 +984,11 @@ class StreamingSwitchGLU:
                     raw = self._shard_for(name).raw(name)
                     per = raw.size // self.num_experts
                     rows = [raw[e * per:(e + 1) * per] for e in hot]
-                # concatenated numpy backing (page cache, not GPU)
+                # concatenated numpy backing (page cache, not GPU), plus
+                # one all-zero row: the prefill path sends misses to row
+                # n_hot ("overflow row") and needs it to contribute zero.
+                # Without it that gather reads past the end of the stack.
+                rows.append(np.zeros_like(rows[0]))
                 backing[(proj, part)] = np.concatenate(rows)
         self._hot_backing = backing
         self._hot_key = key
@@ -1000,7 +1004,7 @@ class StreamingSwitchGLU:
             return
         w = {}
         shape0 = self._bundle_shape
-        n_e = len(self._hot_key)
+        n_e = len(self._hot_key) + 1                 # + zero overflow row
         for (proj, part), buf in self._hot_backing.items():
             shape = shape0[(proj, part)]
             if part == "weight":

--- a/tests/test_streaming_math.py
+++ b/tests/test_streaming_math.py
@@ -274,6 +274,51 @@ def test_hot_stack_matches_exact(layer):
         assert mx.allclose(out, exact).item(), "hot path != exact"
 
 
+def _hot_layer(fuse_gu, td, hot):
+    import os
+    path = os.path.join(td, "w.safetensors")
+    _write_shard(path, fuse_gu)
+    s = StreamingSwitchGLU([SafetensorsMmap(path)], 0, _spec(fuse_gu),
+                           _options(staged=True, hot_per_layer=0),
+                           shared_cache=SharedExpertCache(64))
+    s._hot_counts = {e: 1.0 for e in hot}
+    s.load_hot_layer(n_hot=len(hot))
+    s.materialize_hot()
+    return s
+
+
+def test_hot_stack_has_zero_overflow_row(layer):
+    """Prefill misses are routed to row len(hot_key) of the hot stack and
+    must contribute zero, so that row has to exist and be all zeros --
+    otherwise gather_qmm reads past the end of the stack."""
+    lay, _, _ = layer
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        s = _hot_layer(lay._fuse_gu, td, hot=[0, 2, 5, 7])
+        n = len(s._hot_key)
+        for (proj, part), arr in s._hot_weights.items():
+            assert arr.shape[0] == n + 1, (proj, part, arr.shape)
+            assert not mx.any(arr[n]).item(), (proj, part)
+
+
+def test_hot_stack_with_misses_matches_exact(layer):
+    """Half the routed experts are outside the hot stack: the misses go
+    through the exact scatter-add correction and the result must still
+    equal the exact path."""
+    lay, _, _ = layer
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        s = _hot_layer(lay._fuse_gu, td, hot=[0, 2, 5, 7])
+        x = mx.random.normal((1, 4, DIM)).astype(mx.float16)
+        inds = _inds(tokens=4)
+        assert set(inds.reshape(-1).tolist()) - set(s._hot_key), \
+            "test needs at least one miss"
+        out = s(x, inds)
+        exact = lay(x, inds)
+        assert out.shape == exact.shape
+        assert mx.allclose(out, exact).item(), "hot path with misses != exact"
+
+
 def test_double_buffered_swap(layer):
     """stage_experts fills next; swap promotes; consume uses the new set."""
     lay, _, _ = layer


### PR DESCRIPTION
The hot-stack prefill path in `StreamingSwitchGLU.__call__` maps every routed expert that is not in the hot stack to row `n_rows = len(self._hot_key)` (the "overflow zero row"), runs the fast gather, and then adds the exact contribution of those misses on top. But `load_hot_layer` only builds `n_hot` rows, so every miss makes `gather_qmm` read past the end of the stack. MLX does not bounds-check gathers: the miss slots get whatever sits after the buffer, and the exact correction is added to that instead of to zero.

**Why it went unnoticed:** `test_hot_stack_matches_exact` loads every expert (`n_hot=N_EXPERTS`, "full coverage -> no misses"), so it never produces a miss. On a real checkpoint the result can come out right when the memory after the stack happens to be zero-filled.

**Repro** (current `main`, mlx 0.30.6, Apple M5 Max): same layer as the existing test, but with 4 of the 8 experts hot. At the miss slots the hot path returns values like `-3.6e35`, `8.5e37` and `nan`, where the exact path gives `~797`.

**Fix:** the numpy backing built by `load_hot_layer` carries one extra all-zero row, so the overflow row actually exists and contributes zero. This is the same idea as the staged path's `_zero_slot`. `_build` (slicing an expert out of the backing) and `materialize_hot` account for the extra row. The cost is one expert row per hot layer.

**Tests** (both run for the separate and fused gate/up layouts, and both fail before this change):
- `test_hot_stack_has_zero_overflow_row`: deterministic; the materialized stack has `n_hot + 1` rows and the last one is all zeros.
- `test_hot_stack_with_misses_matches_exact`: hot path == exact path when half the routed experts are misses.

Full suite passes, and so does `pytest -m slow` for edge0-8b.

**Heads-up:** #7 also edits the `_build` hot fast path, including the `per = buf.size // len(self._hot_key)` line this PR changes. Whichever merges second needs a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
